### PR TITLE
Add goreleaser for cross-platform binary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - main: .
+    binary: slyds
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X github.com/panyam/slyds/cmd.Version={{.Version}}
+
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -24,5 +24,5 @@
 ## Polish
 - [x] ~~Better error messages — centralized `findRootIn` with actionable hints~~
 - [x] ~~`slyds version` command + build-time version injection from git tags~~
-- [ ] Release automation / goreleaser setup
+- [x] ~~Release automation / goreleaser setup — tag `v*` triggers cross-platform binary release~~
 - [x] Publish module path (`github.com/panyam/slyds`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,16 @@
 # Roadmap
 
-## v0.1 — Go Rewrite (current)
+## v0.1 — Go Rewrite (done)
 Core CLI rewritten in Go with templar integration. Multi-file slide authoring with `{{# include #}}` composition. All commands working: init, serve, build, add/rm/mv/ls.
 
-## v0.2 — Cleanup & Polish
-Remove legacy Node.js code. Update README. Fix module path. Add live reload to serve. Release binaries.
+## v0.2 — Cleanup & Polish (done)
+Removed legacy Node.js code. Fixed module path. Version command + build-time injection from git tags. Better error messages. Goreleaser for cross-platform binary releases. GitHub Actions CI.
 
-## v0.3 — Theme System
-Multiple built-in themes (default, minimal, dark, corporate, hacker). `--theme` flag on init. Theme preview/switching.
+## v0.3 — Theme System (done)
+Multiple built-in themes (default, minimal, dark, corporate, hacker). `--theme` flag on init. Theme preview/switching. Theme-aware slide rendering from manifest.
+
+## v0.4 — Slide Management (done)
+`slyds insert` with auto-renumber. Index-based ordering (index.html as source of truth). Robust non-prefixed filename handling.
 
 ## v0.4 — Slide Folders
 Support `slides/03-name/slide.html` with co-located assets (images, per-slide CSS). Auto-detect folder vs file slides.


### PR DESCRIPTION
## Summary

Completes v0.2 milestone — release automation.

- **`.goreleaser.yaml`** (v2 format) — cross-compiles for macOS/Linux/Windows × amd64/arm64, injects version via ldflags, runs tests before release, generates checksums
- **`.github/workflows/release.yml`** — triggers on `v*` tag push, creates GitHub Release with binaries
- **Updated ROADMAP.md** — marks v0.1 through v0.4 as done

## Usage

```bash
git tag v0.3.0
git push --tags
# GitHub Actions builds + publishes release automatically
```

## Test plan

- [x] All tests pass
- [x] Config modeled on existing stack pattern (protoc-gen-go-wasmjs)
- [ ] First real release: tag and verify binaries appear on GitHub Releases