### PR TITLE
Add slyds slugify for bulk slug-based slide renaming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ slyds insert <pos> "name" [--type T] [--title T] # Insert slide at position
 slyds rm <name-or-number>                        # Remove slide
 slyds mv <from> <to>                             # Reorder slides
 slyds ls [dir]                                   # List slides (index.html order)
+slyds slugify [dir]                              # Rename all slides to slugs from <h1>
 ```
 
 ## Conventions

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -265,6 +265,132 @@ func runInsert(root string, position int, name, slideType, title string) error {
 	return rewriteSlidesAndIndex(root, newOrder)
 }
 
+var slugifyCmd = &cobra.Command{
+	Use:   "slugify [dir]",
+	Short: "Rename all slides to slug-based filenames from their <h1> content",
+	Long: `Slugify reads each slide's <h1> heading, slugifies it, and renames the file
+to use that slug (preserving the numeric prefix). This makes git diffs cleaner
+when slides are reordered or inserted, since the slug stays stable.
+
+Slides without an <h1> or whose slug already matches are left unchanged.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := "."
+		if len(args) > 0 {
+			dir = args[0]
+		}
+		root, err := findRootIn(dir)
+		if err != nil {
+			return err
+		}
+
+		renamed, err := renameToSlugs(root)
+		if err != nil {
+			return err
+		}
+
+		if renamed == 0 {
+			fmt.Println("All slides already have slug-based names.")
+		} else {
+			fmt.Printf("Renamed %d slide(s).\n", renamed)
+		}
+		return nil
+	},
+}
+
+// renameToSlugs reads each slide's <h1> content, slugifies it, and renames
+// files + updates index.html. Returns the number of slides renamed.
+// Slides without an <h1> or whose slug already matches are left unchanged.
+func renameToSlugs(root string) (int, error) {
+	slides, err := listSlidesFromIndex(root)
+	if err != nil {
+		return 0, err
+	}
+
+	// Build new names, tracking used slugs for deduplication
+	usedSlugs := make(map[string]int)
+	newNames := make([]string, len(slides))
+	renamed := 0
+
+	for i, filename := range slides {
+		heading := extractFirstHeading(filepath.Join(root, "slides", filename))
+		if heading == "" {
+			// No h1 — keep existing name
+			newNames[i] = filename
+			namePart := extractNamePart(filename)
+			slug := strings.TrimSuffix(namePart, ".html")
+			usedSlugs[slug]++
+			continue
+		}
+
+		slug := scaffold.Slugify(heading)
+		usedSlugs[slug]++
+		if usedSlugs[slug] > 1 {
+			slug = fmt.Sprintf("%s-%d", slug, usedSlugs[slug])
+		}
+
+		newName := fmt.Sprintf("%02d-%s.html", i+1, slug)
+		newNames[i] = newName
+		if newName != filename {
+			renamed++
+		}
+	}
+
+	if renamed == 0 {
+		return 0, nil
+	}
+
+	// Use the existing rewrite infrastructure — but we need to rename
+	// files directly since rewriteSlidesAndIndex expects the files to
+	// exist with their OLD names and renames them.
+	slidesDir := filepath.Join(root, "slides")
+
+	// Rename via temp to avoid collisions
+	type renamePair struct{ from, to string }
+	var renames []renamePair
+	for i, oldName := range slides {
+		if newNames[i] != oldName {
+			renames = append(renames, renamePair{oldName, newNames[i]})
+		}
+	}
+	for _, r := range renames {
+		os.Rename(filepath.Join(slidesDir, r.from), filepath.Join(slidesDir, r.from+".tmp"))
+	}
+	for _, r := range renames {
+		os.Rename(filepath.Join(slidesDir, r.from+".tmp"), filepath.Join(slidesDir, r.to))
+	}
+
+	// Rebuild index.html with new names
+	indexPath := filepath.Join(root, "index.html")
+	indexHTML, err := os.ReadFile(indexPath)
+	if err != nil {
+		return 0, err
+	}
+
+	lines := strings.Split(string(indexHTML), "\n")
+	var newLines []string
+	includeInserted := false
+
+	for _, line := range lines {
+		if includeRe.MatchString(line) {
+			if !includeInserted {
+				for _, f := range newNames {
+					newLines = append(newLines, fmt.Sprintf(`    {{# include "slides/%s" #}}`, f))
+				}
+				includeInserted = true
+			}
+			continue
+		}
+		newLines = append(newLines, line)
+	}
+
+	if err := os.WriteFile(indexPath, []byte(strings.Join(newLines, "\n")), 0644); err != nil {
+		return 0, err
+	}
+
+	return renamed, nil
+}
+
 func init() {
 	addCmd.Flags().IntVar(&slideAfter, "after", 0, "insert after slide N")
 	addCmd.Flags().StringVar(&slideType, "type", "content", "slide type: title, content, closing, two-column, section")
@@ -275,6 +401,7 @@ func init() {
 	rootCmd.AddCommand(mvCmd)
 	rootCmd.AddCommand(lsCmd)
 	rootCmd.AddCommand(insertCmd)
+	rootCmd.AddCommand(slugifyCmd)
 }
 
 // extractNamePart strips the numeric prefix (e.g., "01-") from a slide filename,

--- a/cmd/slides_test.go
+++ b/cmd/slides_test.go
@@ -549,3 +549,137 @@ func TestMultipleInserts(t *testing.T) {
 		}
 	}
 }
+
+// TestRenameSlugs verifies that renameToSlugs reads each slide's <h1> content,
+// slugifies it, and renames files + updates index.html accordingly. Slides
+// whose slug already matches their current name should be left unchanged.
+func TestRenameSlugs(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Scaffolded slides: 01-title.html (<h1>Test Pres</h1>),
+	// 02-slide.html (<h1>Slide 2</h1>), 03-slide.html (<h1>Slide 3</h1>),
+	// 04-closing.html (<h1>Thank You</h1>)
+	renamed, err := renameToSlugs(root)
+	if err != nil {
+		t.Fatalf("renameToSlugs failed: %v", err)
+	}
+
+	if renamed != 4 {
+		t.Errorf("expected 4 renames, got %d", renamed)
+	}
+
+	slides, _ := listSlidesFromIndex(root)
+
+	// 01-title.html → 01-test-pres.html (title slide has <h1>Test Pres</h1>)
+	if slides[0] != "01-test-pres.html" {
+		t.Errorf("expected 01-test-pres.html, got %s", slides[0])
+	}
+	// 02-slide.html → 02-slide-2.html
+	if slides[1] != "02-slide-2.html" {
+		t.Errorf("expected 02-slide-2.html, got %s", slides[1])
+	}
+	// 03-slide.html → 03-slide-3.html
+	if slides[2] != "03-slide-3.html" {
+		t.Errorf("expected 03-slide-3.html, got %s", slides[2])
+	}
+	// 04-closing.html → 04-thank-you.html
+	if slides[3] != "04-thank-you.html" {
+		t.Errorf("expected 04-thank-you.html, got %s", slides[3])
+	}
+
+	// Verify index.html references match
+	indexHTML, _ := os.ReadFile(filepath.Join(root, "index.html"))
+	indexStr := string(indexHTML)
+	for _, s := range slides {
+		if !strings.Contains(indexStr, fmt.Sprintf(`"slides/%s"`, s)) {
+			t.Errorf("index.html missing include for %s", s)
+		}
+	}
+}
+
+// TestRenameSlugsIdempotent verifies that running renameToSlugs twice produces
+// the same result — slides already matching their h1 slug are not renamed again.
+func TestRenameSlugsIdempotent(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	renameToSlugs(root)
+	renamed, err := renameToSlugs(root)
+	if err != nil {
+		t.Fatalf("second renameToSlugs failed: %v", err)
+	}
+	if renamed != 0 {
+		t.Errorf("expected 0 renames on second run, got %d", renamed)
+	}
+}
+
+// TestRenameSlugsNoHeading verifies that slides without an <h1> tag keep
+// their existing name rather than being renamed to an empty slug.
+func TestRenameSlugsNoHeading(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Replace slide 2 content with no heading
+	slidePath := filepath.Join(root, "slides", "02-slide.html")
+	os.WriteFile(slidePath, []byte(`<div class="slide"><p>No heading here</p></div>`), 0644)
+
+	_, err := renameToSlugs(root)
+	if err != nil {
+		t.Fatalf("renameToSlugs failed: %v", err)
+	}
+
+	// Slide 2 should keep its existing name part since there's no h1
+	slides, _ := listSlidesFromIndex(root)
+	if slides[1] != "02-slide.html" {
+		t.Errorf("expected 02-slide.html (no h1 to slug from), got %s", slides[1])
+	}
+}
+
+// TestRenameSlugsPreservesContent verifies that renaming does not modify
+// the actual HTML content of any slide file.
+func TestRenameSlugsPreservesContent(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Read original content
+	origContent, _ := os.ReadFile(filepath.Join(root, "slides", "02-slide.html"))
+
+	renameToSlugs(root)
+
+	// Content should be identical, just in a new file
+	newContent, err := os.ReadFile(filepath.Join(root, "slides", "02-slide-2.html"))
+	if err != nil {
+		t.Fatalf("failed to read renamed slide: %v", err)
+	}
+	if string(origContent) != string(newContent) {
+		t.Error("slide content was modified during rename")
+	}
+}
+
+// TestRenameSlugsDeduplicates verifies that when two slides have the same <h1>
+// text, the rename produces unique filenames by appending a suffix.
+func TestRenameSlugsDeduplicates(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Set slides 2 and 3 to have the same heading
+	for _, f := range []string{"02-slide.html", "03-slide.html"} {
+		path := filepath.Join(root, "slides", f)
+		os.WriteFile(path, []byte(`<div class="slide"><h1>Same Title</h1></div>`), 0644)
+	}
+
+	_, err := renameToSlugs(root)
+	if err != nil {
+		t.Fatalf("renameToSlugs failed: %v", err)
+	}
+
+	slides, _ := listSlidesFromIndex(root)
+	// Both should have "same-title" but one needs a suffix
+	if slides[1] != "02-same-title.html" {
+		t.Errorf("expected 02-same-title.html, got %s", slides[1])
+	}
+	if slides[2] != "03-same-title-2.html" {
+		t.Errorf("expected 03-same-title-2.html, got %s", slides[2])
+	}
+}


### PR DESCRIPTION
## Summary

Closes #10

Adds `slyds slugify [dir]` — reads each slide's `<h1>` heading, slugifies it, and renames the file (preserving the numeric prefix). Updates `index.html` includes to match.

**Before:** `01-title.html`, `02-slide.html`, `03-slide.html`, `04-closing.html`
**After:** `01-test-pres.html`, `02-why-we-built-this.html`, `03-architecture-overview.html`, `04-thank-you.html`

This makes git diffs cleaner when slides are reordered or inserted — the slug stays stable, only the prefix changes.

**Edge cases handled:**
- No `<h1>` → keeps existing name
- Duplicate headings → appends `-2`, `-3` suffix
- Already slugified → idempotent (0 renames on second run)
- Content preserved during rename

## Test plan

- [x] 5 new tests: basic rename, idempotent, no heading, content preservation, deduplication
- [x] All 57 tests pass