### PR TITLE
Add slyds check command for deck validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ slyds rm <name-or-number>                        # Remove slide
 slyds mv <from> <to>                             # Reorder slides
 slyds ls [dir]                                   # List slides (index.html order)
 slyds slugify [dir]                              # Rename all slides to slugs from <h1>
+slyds check [dir]                                # Validate deck (sync, notes, assets)
 ```
 
 ## Conventions

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// CheckResult holds the results of a deck validation.
+type CheckResult struct {
+	SlideCount       int
+	InSync           bool
+	Errors           []string
+	Warnings         []string
+	EstimatedMinutes float64
+}
+
+var assetRefRe = regexp.MustCompile(`(?:src|href)="([^"]+)"`)
+var speakerNotesRe = regexp.MustCompile(`class="speaker-notes"`)
+
+var checkCmd = &cobra.Command{
+	Use:   "check [dir]",
+	Short: "Validate a presentation deck",
+	Long: `Check validates a presentation for common issues:
+- Slides referenced in index.html that don't exist on disk
+- Slide files on disk not referenced in index.html (orphans)
+- Slides missing speaker notes
+- Broken local asset references (images, videos)
+- Estimated talk time from speaker notes word count`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := "."
+		if len(args) > 0 {
+			dir = args[0]
+		}
+		root, err := findRootIn(dir)
+		if err != nil {
+			return err
+		}
+
+		result, err := checkDeck(root)
+		if err != nil {
+			return err
+		}
+
+		// Print results
+		fmt.Printf("%d slides", result.SlideCount)
+		if result.InSync {
+			fmt.Println(", index.html in sync")
+		} else {
+			fmt.Println(", index.html OUT OF SYNC")
+		}
+
+		for _, e := range result.Errors {
+			fmt.Printf("  ERROR: %s\n", e)
+		}
+		for _, w := range result.Warnings {
+			fmt.Printf("  WARN:  %s\n", w)
+		}
+
+		if result.EstimatedMinutes > 0 {
+			fmt.Printf("  Estimated talk time: ~%.0f min\n", result.EstimatedMinutes)
+		}
+
+		if len(result.Errors) > 0 {
+			return fmt.Errorf("%d error(s) found", len(result.Errors))
+		}
+		return nil
+	},
+}
+
+func checkDeck(root string) (*CheckResult, error) {
+	result := &CheckResult{InSync: true}
+
+	// Get slides from index.html and from filesystem
+	indexSlides, err := listSlidesFromIndex(root)
+	if err != nil {
+		return nil, err
+	}
+	diskSlides := listSlideFiles(root)
+
+	result.SlideCount = len(indexSlides)
+
+	// Build sets for comparison
+	indexSet := make(map[string]bool)
+	for _, s := range indexSlides {
+		indexSet[s] = true
+	}
+	diskSet := make(map[string]bool)
+	for _, s := range diskSlides {
+		diskSet[s] = true
+	}
+
+	// Check for missing files (in index but not on disk)
+	for _, s := range indexSlides {
+		if !diskSet[s] {
+			result.Errors = append(result.Errors, fmt.Sprintf("%s referenced in index.html but not found on disk", s))
+			result.InSync = false
+		}
+	}
+
+	// Check for orphan files (on disk but not in index)
+	for _, s := range diskSlides {
+		if !indexSet[s] {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("%s on disk but not in index.html (orphan)", s))
+			result.InSync = false
+		}
+	}
+
+	// Check each slide for speaker notes, broken assets
+	totalWords := 0
+	slidesDir := filepath.Join(root, "slides")
+
+	for _, s := range indexSlides {
+		slidePath := filepath.Join(slidesDir, s)
+		data, err := os.ReadFile(slidePath)
+		if err != nil {
+			continue // already flagged as missing
+		}
+		content := string(data)
+
+		// Check speaker notes
+		if !speakerNotesRe.MatchString(content) {
+			result.Warnings = append(result.Warnings, fmt.Sprintf("%s: no speaker notes", s))
+		}
+
+		// Count words in speaker notes for talk time estimate
+		if idx := strings.Index(content, `class="speaker-notes"`); idx >= 0 {
+			notesSection := content[idx:]
+			// Strip HTML tags for word counting
+			tagRe := regexp.MustCompile(`<[^>]+>`)
+			text := tagRe.ReplaceAllString(notesSection, " ")
+			words := strings.Fields(text)
+			totalWords += len(words)
+		}
+
+		// Check local asset references
+		matches := assetRefRe.FindAllStringSubmatch(content, -1)
+		for _, m := range matches {
+			ref := m[1]
+			// Skip remote URLs, anchors, and CSS/JS (already handled)
+			if strings.HasPrefix(ref, "http://") || strings.HasPrefix(ref, "https://") ||
+				strings.HasPrefix(ref, "#") || strings.HasPrefix(ref, "data:") ||
+				strings.HasSuffix(ref, ".css") || strings.HasSuffix(ref, ".js") {
+				continue
+			}
+			// Resolve relative to presentation root (slides reference assets relative to root)
+			assetPath := filepath.Join(root, ref)
+			if _, err := os.Stat(assetPath); os.IsNotExist(err) {
+				// Also try relative to slides dir
+				assetPath = filepath.Join(slidesDir, ref)
+				if _, err := os.Stat(assetPath); os.IsNotExist(err) {
+					result.Warnings = append(result.Warnings, fmt.Sprintf("%s: broken asset reference %q", s, ref))
+				}
+			}
+		}
+	}
+
+	// Estimate talk time: ~150 words per minute
+	if totalWords > 0 {
+		result.EstimatedMinutes = float64(totalWords) / 150.0
+	}
+
+	return result, nil
+}
+
+func init() {
+	rootCmd.AddCommand(checkCmd)
+}

--- a/cmd/slides_test.go
+++ b/cmd/slides_test.go
@@ -683,3 +683,153 @@ func TestRenameSlugsDeduplicates(t *testing.T) {
 		t.Errorf("expected 03-same-title-2.html, got %s", slides[2])
 	}
 }
+
+// TestCheckCleanDeck verifies that checkDeck returns no warnings and no errors
+// for a freshly scaffolded presentation where everything is in sync.
+func TestCheckCleanDeck(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	result, err := checkDeck(root)
+	if err != nil {
+		t.Fatalf("checkDeck failed: %v", err)
+	}
+
+	if len(result.Errors) != 0 {
+		t.Errorf("expected no errors, got: %v", result.Errors)
+	}
+	if result.SlideCount != 4 {
+		t.Errorf("expected 4 slides, got %d", result.SlideCount)
+	}
+	if !result.InSync {
+		t.Error("expected index.html to be in sync with slide files")
+	}
+}
+
+// TestCheckOrphanFiles verifies that checkDeck detects slide files on disk
+// that are not referenced in index.html.
+func TestCheckOrphanFiles(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Add an orphan file not in index.html
+	os.WriteFile(filepath.Join(root, "slides", "orphan.html"), []byte("<div>orphan</div>"), 0644)
+
+	result, _ := checkDeck(root)
+	if result.InSync {
+		t.Error("expected out of sync when orphan file exists")
+	}
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "orphan.html") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about orphan.html, got: %v", result.Warnings)
+	}
+}
+
+// TestCheckMissingFiles verifies that checkDeck detects slides referenced in
+// index.html that don't exist on disk.
+func TestCheckMissingFiles(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Delete a slide file but leave index.html reference
+	os.Remove(filepath.Join(root, "slides", "02-slide.html"))
+
+	result, _ := checkDeck(root)
+	if result.InSync {
+		t.Error("expected out of sync when file is missing")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "02-slide.html") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about missing 02-slide.html, got: %v", result.Errors)
+	}
+}
+
+// TestCheckMissingSpeakerNotes verifies that checkDeck warns about slides
+// that have no speaker-notes div or have an empty one.
+func TestCheckMissingSpeakerNotes(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Replace slide 2 with content that has no speaker notes
+	os.WriteFile(filepath.Join(root, "slides", "02-slide.html"),
+		[]byte(`<div class="slide"><h1>No Notes</h1><p>Content</p></div>`), 0644)
+
+	result, _ := checkDeck(root)
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "02-slide.html") && strings.Contains(w, "speaker notes") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about missing speaker notes, got: %v", result.Warnings)
+	}
+}
+
+// TestCheckBrokenAssetRef verifies that checkDeck detects local asset
+// references (src="...", href="...") that point to files that don't exist.
+func TestCheckBrokenAssetRef(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	// Add a slide with a broken image reference
+	os.WriteFile(filepath.Join(root, "slides", "02-slide.html"),
+		[]byte(`<div class="slide"><h1>Demo</h1><img src="images/missing.png"><div class="speaker-notes"><p>notes</p></div></div>`), 0644)
+
+	result, _ := checkDeck(root)
+
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "missing.png") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warning about missing.png, got: %v", result.Warnings)
+	}
+}
+
+// TestCheckTalkTime verifies that checkDeck estimates talk time from
+// speaker notes word count.
+func TestCheckTalkTime(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	result, _ := checkDeck(root)
+
+	// Scaffolded slides have some speaker notes, so time should be > 0
+	if result.EstimatedMinutes <= 0 {
+		t.Error("expected positive estimated talk time")
+	}
+}
+
+// TestCheckRemoteAssetIgnored verifies that checkDeck does not flag
+// remote URLs (http/https) as broken asset references.
+func TestCheckRemoteAssetIgnored(t *testing.T) {
+	root, cleanup := setupTestPresentation(t)
+	defer cleanup()
+
+	os.WriteFile(filepath.Join(root, "slides", "02-slide.html"),
+		[]byte(`<div class="slide"><h1>Demo</h1><img src="https://example.com/img.png"><div class="speaker-notes"><p>notes</p></div></div>`), 0644)
+
+	result, _ := checkDeck(root)
+
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "example.com") {
+			t.Errorf("should not warn about remote URLs, got: %s", w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Partially addresses #9 (check only, preview deferred).

`slyds check [dir]` validates a presentation deck:

- **Sync check** — slides in index.html vs files on disk (missing files = error, orphans = warning)
- **Speaker notes** — warns on slides without `<div class="speaker-notes">`
- **Broken assets** — checks local `src`/`href` references exist (ignores remote URLs)
- **Talk time** — estimates from speaker notes word count (~150 wpm)
- **CI-friendly** — returns non-zero exit code on errors

Example output:
```
4 slides, index.html in sync
  WARN:  02-slide.html: no speaker notes
  WARN:  03-slide.html: broken asset reference "images/missing.png"
  Estimated talk time: ~3 min
```

## Test plan

- [x] 7 new tests: clean deck, orphan files, missing files, missing speaker notes, broken assets, talk time, remote URL ignored
- [x] All 64 tests pass