### PR TITLE
Add presenter timer and reading time to speaker notes

### DIFF
--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -17,6 +17,7 @@
 - [x] ~~Client-side slide export/download from built presentations (issue #20)~~
 - [x] ~~Shared `index.html.tmpl` with theme-specific override support — reduces cross-theme duplication~~
 - [x] ~~Example presentations — 3 demo decks (intro, rich-content, hacker) with GitHub Pages deployment~~
+- [x] ~~Presenter timer + reading time in speaker notes window (issue #22 phase 1)~~
 - [ ] Slide navigation hooks — drive demos from slide transitions (issue #1)
 - [ ] Interactive slides with TypeScript/esbuild support (issue #3)
 - [x] ~~Theme static asset copying (images, fonts) during scaffold~~

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ No template syntax needed in slide files. The first slide gets `class="slide act
 | `→` | Next slide |
 | `←` | Previous slide |
 | `N` | Open speaker notes window |
+| `T` | Start/pause presentation timer |
 | `Esc` | Close notes window |
+
+The speaker notes window includes an elapsed timer, per-slide reading time estimate (~200 WPM), and remaining deck time. Timer state persists across notes window close/reopen.
 
 ## Built-in CSS Classes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,6 +21,9 @@ Client-side slide export/download from built presentations. Download button in n
 ## v0.6.1 — Examples & Documentation
 Three example presentations (slyds-intro, rich-content, hacker-showcase) demonstrating themes and CSS components. GitHub Pages deployment via `make gh-pages`. `make examples` build target.
 
+## v0.6.2 — Presenter Timer
+Elapsed presentation timer, per-slide reading time (~200 WPM), and remaining deck time in the speaker notes window. Toggle with T key. Timer state persists across notes window close/reopen.
+
 ## v0.7 — Slide Folders
 Support `slides/03-name/slide.html` with co-located assets (images, per-slide CSS). Auto-detect folder vs file slides.
 

--- a/assets/slyds.js
+++ b/assets/slyds.js
@@ -8,6 +8,16 @@
     var totalSlides = document.querySelectorAll('.slide').length;
     var notesWindow = null;
 
+    // Timer state — lives in main window so closing/reopening notes preserves it
+    var timerStart = null;
+    var timerPaused = false;
+    var timerElapsed = 0;
+    var timerInterval = null;
+
+    // Reading time — computed once on load
+    var slideReadingTimes = [];
+    var WPM = 200;
+
     // Write total into counter (if element exists)
     var totalEl = document.getElementById('totalSlides');
     if (totalEl) totalEl.textContent = totalSlides;
@@ -28,6 +38,114 @@
     }
 
     var currentSlide = getSlideFromHash();
+
+    // ── Reading time computation ──
+    // Computes word count and estimated reading time for each slide's
+    // visible content (excludes speaker notes). Called once on load.
+    function computeReadingTimes() {
+        var slides = document.querySelectorAll('.slide');
+        slideReadingTimes = [];
+        slides.forEach(function (slide) {
+            var clone = slide.cloneNode(true);
+            var notes = clone.querySelector('.speaker-notes');
+            if (notes) notes.remove();
+            var text = clone.textContent || '';
+            var words = text.trim().split(/\s+/).filter(function (w) { return w.length > 0; });
+            slideReadingTimes.push(Math.ceil(words.length / WPM * 60));
+        });
+    }
+
+    // Returns reading time in seconds for slide n (1-indexed)
+    function getReadingTime(n) {
+        return slideReadingTimes[n - 1] || 0;
+    }
+
+    // Returns total remaining reading time in seconds from current slide onward
+    function getRemainingReadingTime() {
+        var total = 0;
+        for (var i = currentSlide; i < totalSlides; i++) {
+            total += (slideReadingTimes[i] || 0);
+        }
+        return total;
+    }
+
+    // ── Timer functions ──
+
+    function getElapsedMs() {
+        if (timerStart !== null && !timerPaused) {
+            return timerElapsed + (Date.now() - timerStart);
+        }
+        return timerElapsed;
+    }
+
+    function formatTime(ms) {
+        var totalSec = Math.floor(ms / 1000);
+        var h = Math.floor(totalSec / 3600);
+        var m = Math.floor((totalSec % 3600) / 60);
+        var s = totalSec % 60;
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        if (h > 0) {
+            return h + ':' + pad(m) + ':' + pad(s);
+        }
+        return m + ':' + pad(s);
+    }
+
+    function formatReadingTime(seconds) {
+        if (seconds < 60) return '< 1 min';
+        var mins = Math.round(seconds / 60);
+        return '~' + mins + ' min';
+    }
+
+    function timerButtonLabel() {
+        if (timerStart === null && timerElapsed === 0) return 'Start';
+        if (timerPaused) return 'Resume';
+        return 'Pause';
+    }
+
+    function updateTimerDisplay() {
+        if (notesWindow && !notesWindow.closed) {
+            var timerEl = notesWindow.document.getElementById('notesTimer');
+            if (timerEl) timerEl.textContent = formatTime(getElapsedMs());
+        }
+    }
+
+    function startTimer() {
+        timerStart = Date.now();
+        timerPaused = false;
+        timerInterval = setInterval(updateTimerDisplay, 1000);
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function pauseTimer() {
+        timerElapsed += (Date.now() - timerStart);
+        timerStart = null;
+        timerPaused = true;
+        clearInterval(timerInterval);
+        timerInterval = null;
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function toggleTimer() {
+        if (timerStart === null && !timerPaused && timerElapsed === 0) {
+            startTimer();
+        } else if (timerPaused || timerStart === null) {
+            startTimer();
+        } else {
+            pauseTimer();
+        }
+    }
+
+    function updateNotesTimerUI() {
+        if (!notesWindow || notesWindow.closed) return;
+        var btn = notesWindow.document.getElementById('notesTimerToggle');
+        if (btn) btn.textContent = timerButtonLabel();
+        var readEl = notesWindow.document.getElementById('notesReadingTime');
+        if (readEl) readEl.textContent = formatReadingTime(getReadingTime(currentSlide)) + ' read';
+        var remEl = notesWindow.document.getElementById('notesRemaining');
+        if (remEl) remEl.textContent = formatReadingTime(getRemainingReadingTime()) + ' remaining';
+    }
 
     // Get speaker notes from the DOM
     function getNotesForSlide(n) {
@@ -86,6 +204,8 @@
         if (notesWindow) {
             var title = getSlideTitleForSlide(currentSlide);
             var notes = getNotesForSlide(currentSlide);
+            var readTime = formatReadingTime(getReadingTime(currentSlide));
+            var remaining = formatReadingTime(getRemainingReadingTime());
 
             // Build notes window HTML — uses document.write because we're
             // populating a blank popup window (no XSS risk: content is from
@@ -99,6 +219,11 @@
                 '.header { background: #34495e; padding: 20px; margin: -30px -30px 30px -30px; border-bottom: 3px solid #3498db; }',
                 'h1 { color: #3498db; margin: 0; font-size: 1.8em; }',
                 '.slide-info { color: #bdc3c7; margin-top: 5px; font-size: 1.1em; }',
+                '.timer-bar { display: flex; align-items: center; gap: 16px; margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(255,255,255,0.1); }',
+                '.timer-bar .elapsed { font-family: "SF Mono", "JetBrains Mono", monospace; font-size: 1.4em; color: #2ecc71; font-weight: bold; min-width: 70px; }',
+                '.timer-bar .meta { color: #95a5a6; font-size: 0.9em; }',
+                '.timer-bar .timer-btn { background: #3498db; color: white; border: none; padding: 5px 14px; border-radius: 4px; cursor: pointer; font-size: 0.85em; font-weight: 600; }',
+                '.timer-bar .timer-btn:hover { background: #2980b9; }',
                 'h2 { color: #3498db; margin-top: 30px; margin-bottom: 15px; font-size: 1.4em; }',
                 'h3 { color: #e74c3c; margin-top: 25px; margin-bottom: 10px; font-size: 1.2em; }',
                 'p, li { font-size: 1em; line-height: 1.6; margin-bottom: 12px; }',
@@ -113,6 +238,12 @@
                 '<div class="header">',
                 '<h1 id="notesTitle">' + title + '</h1>',
                 '<div class="slide-info">Slide <span id="slideNumber">' + currentSlide + '</span> of ' + totalSlides + '</div>',
+                '<div class="timer-bar">',
+                '<span class="elapsed" id="notesTimer">' + formatTime(getElapsedMs()) + '</span>',
+                '<span class="meta" id="notesReadingTime">' + readTime + ' read</span>',
+                '<span class="meta" id="notesRemaining">' + remaining + ' remaining</span>',
+                '<button class="timer-btn" id="notesTimerToggle" onclick="window.opener.toggleTimer()">' + timerButtonLabel() + '</button>',
+                '</div>',
                 '</div>',
                 '<div class="content" id="notesContent">' + notes + '</div>',
                 '</body>',
@@ -140,6 +271,10 @@
                 contentElement.innerHTML = notes;
                 notesWindow.document.title = 'Speaker Notes - ' + title;
             }
+
+            // Update timer display and reading times
+            updateTimerDisplay();
+            updateNotesTimerUI();
         }
     }
 
@@ -155,6 +290,7 @@
         if (e.key === 'ArrowRight') changeSlide(1);
         if (e.key === 'Escape') closeNotesWindow();
         if (e.key === 'n' || e.key === 'N') openNotesWindow();
+        if (e.key === 't' || e.key === 'T') toggleTimer();
     });
 
     // Handle browser back/forward buttons
@@ -184,7 +320,9 @@
     // Expose to onclick handlers in HTML
     window.changeSlide = changeSlide;
     window.openNotesWindow = openNotesWindow;
+    window.toggleTimer = toggleTimer;
 
     // Initialize
+    computeReadingTimes();
     showSlide(currentSlide);
 })();

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -198,6 +198,37 @@ func TestExampleContentNotPlaceholder(t *testing.T) {
 	}
 }
 
+// TestExampleBuildContainsTimer verifies that each example deck's built
+// output includes the presenter timer and reading time features. Checks
+// for the toggleTimer function, the notes window timer UI elements, and
+// the reading time computation — ensuring the timer feature is present
+// in all shipped examples.
+func TestExampleBuildContainsTimer(t *testing.T) {
+	root := examplesDir(t)
+
+	timerMarkers := []string{
+		"toggleTimer",
+		"computeReadingTimes",
+		"notesTimer",
+		"notesTimerToggle",
+		"formatReadingTime",
+	}
+
+	for _, deck := range decks {
+		t.Run(deck.dir, func(t *testing.T) {
+			result, err := builder.Build(filepath.Join(root, deck.dir))
+			if err != nil {
+				t.Fatalf("Build failed: %v", err)
+			}
+			for _, marker := range timerMarkers {
+				if !strings.Contains(result.HTML, marker) {
+					t.Errorf("built output missing timer marker: %s", marker)
+				}
+			}
+		})
+	}
+}
+
 // TestExampleSpeakerNotes verifies that every slide in each example deck
 // contains a speaker-notes section. This ensures presenters always have
 // notes available and validates consistent slide authoring.

--- a/examples/hacker-showcase/slyds.js
+++ b/examples/hacker-showcase/slyds.js
@@ -8,6 +8,16 @@
     var totalSlides = document.querySelectorAll('.slide').length;
     var notesWindow = null;
 
+    // Timer state — lives in main window so closing/reopening notes preserves it
+    var timerStart = null;
+    var timerPaused = false;
+    var timerElapsed = 0;
+    var timerInterval = null;
+
+    // Reading time — computed once on load
+    var slideReadingTimes = [];
+    var WPM = 200;
+
     // Write total into counter (if element exists)
     var totalEl = document.getElementById('totalSlides');
     if (totalEl) totalEl.textContent = totalSlides;
@@ -28,6 +38,114 @@
     }
 
     var currentSlide = getSlideFromHash();
+
+    // ── Reading time computation ──
+    // Computes word count and estimated reading time for each slide's
+    // visible content (excludes speaker notes). Called once on load.
+    function computeReadingTimes() {
+        var slides = document.querySelectorAll('.slide');
+        slideReadingTimes = [];
+        slides.forEach(function (slide) {
+            var clone = slide.cloneNode(true);
+            var notes = clone.querySelector('.speaker-notes');
+            if (notes) notes.remove();
+            var text = clone.textContent || '';
+            var words = text.trim().split(/\s+/).filter(function (w) { return w.length > 0; });
+            slideReadingTimes.push(Math.ceil(words.length / WPM * 60));
+        });
+    }
+
+    // Returns reading time in seconds for slide n (1-indexed)
+    function getReadingTime(n) {
+        return slideReadingTimes[n - 1] || 0;
+    }
+
+    // Returns total remaining reading time in seconds from current slide onward
+    function getRemainingReadingTime() {
+        var total = 0;
+        for (var i = currentSlide; i < totalSlides; i++) {
+            total += (slideReadingTimes[i] || 0);
+        }
+        return total;
+    }
+
+    // ── Timer functions ──
+
+    function getElapsedMs() {
+        if (timerStart !== null && !timerPaused) {
+            return timerElapsed + (Date.now() - timerStart);
+        }
+        return timerElapsed;
+    }
+
+    function formatTime(ms) {
+        var totalSec = Math.floor(ms / 1000);
+        var h = Math.floor(totalSec / 3600);
+        var m = Math.floor((totalSec % 3600) / 60);
+        var s = totalSec % 60;
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        if (h > 0) {
+            return h + ':' + pad(m) + ':' + pad(s);
+        }
+        return m + ':' + pad(s);
+    }
+
+    function formatReadingTime(seconds) {
+        if (seconds < 60) return '< 1 min';
+        var mins = Math.round(seconds / 60);
+        return '~' + mins + ' min';
+    }
+
+    function timerButtonLabel() {
+        if (timerStart === null && timerElapsed === 0) return 'Start';
+        if (timerPaused) return 'Resume';
+        return 'Pause';
+    }
+
+    function updateTimerDisplay() {
+        if (notesWindow && !notesWindow.closed) {
+            var timerEl = notesWindow.document.getElementById('notesTimer');
+            if (timerEl) timerEl.textContent = formatTime(getElapsedMs());
+        }
+    }
+
+    function startTimer() {
+        timerStart = Date.now();
+        timerPaused = false;
+        timerInterval = setInterval(updateTimerDisplay, 1000);
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function pauseTimer() {
+        timerElapsed += (Date.now() - timerStart);
+        timerStart = null;
+        timerPaused = true;
+        clearInterval(timerInterval);
+        timerInterval = null;
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function toggleTimer() {
+        if (timerStart === null && !timerPaused && timerElapsed === 0) {
+            startTimer();
+        } else if (timerPaused || timerStart === null) {
+            startTimer();
+        } else {
+            pauseTimer();
+        }
+    }
+
+    function updateNotesTimerUI() {
+        if (!notesWindow || notesWindow.closed) return;
+        var btn = notesWindow.document.getElementById('notesTimerToggle');
+        if (btn) btn.textContent = timerButtonLabel();
+        var readEl = notesWindow.document.getElementById('notesReadingTime');
+        if (readEl) readEl.textContent = formatReadingTime(getReadingTime(currentSlide)) + ' read';
+        var remEl = notesWindow.document.getElementById('notesRemaining');
+        if (remEl) remEl.textContent = formatReadingTime(getRemainingReadingTime()) + ' remaining';
+    }
 
     // Get speaker notes from the DOM
     function getNotesForSlide(n) {
@@ -86,6 +204,8 @@
         if (notesWindow) {
             var title = getSlideTitleForSlide(currentSlide);
             var notes = getNotesForSlide(currentSlide);
+            var readTime = formatReadingTime(getReadingTime(currentSlide));
+            var remaining = formatReadingTime(getRemainingReadingTime());
 
             // Build notes window HTML — uses document.write because we're
             // populating a blank popup window (no XSS risk: content is from
@@ -99,6 +219,11 @@
                 '.header { background: #34495e; padding: 20px; margin: -30px -30px 30px -30px; border-bottom: 3px solid #3498db; }',
                 'h1 { color: #3498db; margin: 0; font-size: 1.8em; }',
                 '.slide-info { color: #bdc3c7; margin-top: 5px; font-size: 1.1em; }',
+                '.timer-bar { display: flex; align-items: center; gap: 16px; margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(255,255,255,0.1); }',
+                '.timer-bar .elapsed { font-family: "SF Mono", "JetBrains Mono", monospace; font-size: 1.4em; color: #2ecc71; font-weight: bold; min-width: 70px; }',
+                '.timer-bar .meta { color: #95a5a6; font-size: 0.9em; }',
+                '.timer-bar .timer-btn { background: #3498db; color: white; border: none; padding: 5px 14px; border-radius: 4px; cursor: pointer; font-size: 0.85em; font-weight: 600; }',
+                '.timer-bar .timer-btn:hover { background: #2980b9; }',
                 'h2 { color: #3498db; margin-top: 30px; margin-bottom: 15px; font-size: 1.4em; }',
                 'h3 { color: #e74c3c; margin-top: 25px; margin-bottom: 10px; font-size: 1.2em; }',
                 'p, li { font-size: 1em; line-height: 1.6; margin-bottom: 12px; }',
@@ -113,6 +238,12 @@
                 '<div class="header">',
                 '<h1 id="notesTitle">' + title + '</h1>',
                 '<div class="slide-info">Slide <span id="slideNumber">' + currentSlide + '</span> of ' + totalSlides + '</div>',
+                '<div class="timer-bar">',
+                '<span class="elapsed" id="notesTimer">' + formatTime(getElapsedMs()) + '</span>',
+                '<span class="meta" id="notesReadingTime">' + readTime + ' read</span>',
+                '<span class="meta" id="notesRemaining">' + remaining + ' remaining</span>',
+                '<button class="timer-btn" id="notesTimerToggle" onclick="window.opener.toggleTimer()">' + timerButtonLabel() + '</button>',
+                '</div>',
                 '</div>',
                 '<div class="content" id="notesContent">' + notes + '</div>',
                 '</body>',
@@ -140,6 +271,10 @@
                 contentElement.innerHTML = notes;
                 notesWindow.document.title = 'Speaker Notes - ' + title;
             }
+
+            // Update timer display and reading times
+            updateTimerDisplay();
+            updateNotesTimerUI();
         }
     }
 
@@ -155,6 +290,7 @@
         if (e.key === 'ArrowRight') changeSlide(1);
         if (e.key === 'Escape') closeNotesWindow();
         if (e.key === 'n' || e.key === 'N') openNotesWindow();
+        if (e.key === 't' || e.key === 'T') toggleTimer();
     });
 
     // Handle browser back/forward buttons
@@ -184,7 +320,9 @@
     // Expose to onclick handlers in HTML
     window.changeSlide = changeSlide;
     window.openNotesWindow = openNotesWindow;
+    window.toggleTimer = toggleTimer;
 
     // Initialize
+    computeReadingTimes();
     showSlide(currentSlide);
 })();

--- a/examples/rich-content/slyds.js
+++ b/examples/rich-content/slyds.js
@@ -8,6 +8,16 @@
     var totalSlides = document.querySelectorAll('.slide').length;
     var notesWindow = null;
 
+    // Timer state — lives in main window so closing/reopening notes preserves it
+    var timerStart = null;
+    var timerPaused = false;
+    var timerElapsed = 0;
+    var timerInterval = null;
+
+    // Reading time — computed once on load
+    var slideReadingTimes = [];
+    var WPM = 200;
+
     // Write total into counter (if element exists)
     var totalEl = document.getElementById('totalSlides');
     if (totalEl) totalEl.textContent = totalSlides;
@@ -28,6 +38,114 @@
     }
 
     var currentSlide = getSlideFromHash();
+
+    // ── Reading time computation ──
+    // Computes word count and estimated reading time for each slide's
+    // visible content (excludes speaker notes). Called once on load.
+    function computeReadingTimes() {
+        var slides = document.querySelectorAll('.slide');
+        slideReadingTimes = [];
+        slides.forEach(function (slide) {
+            var clone = slide.cloneNode(true);
+            var notes = clone.querySelector('.speaker-notes');
+            if (notes) notes.remove();
+            var text = clone.textContent || '';
+            var words = text.trim().split(/\s+/).filter(function (w) { return w.length > 0; });
+            slideReadingTimes.push(Math.ceil(words.length / WPM * 60));
+        });
+    }
+
+    // Returns reading time in seconds for slide n (1-indexed)
+    function getReadingTime(n) {
+        return slideReadingTimes[n - 1] || 0;
+    }
+
+    // Returns total remaining reading time in seconds from current slide onward
+    function getRemainingReadingTime() {
+        var total = 0;
+        for (var i = currentSlide; i < totalSlides; i++) {
+            total += (slideReadingTimes[i] || 0);
+        }
+        return total;
+    }
+
+    // ── Timer functions ──
+
+    function getElapsedMs() {
+        if (timerStart !== null && !timerPaused) {
+            return timerElapsed + (Date.now() - timerStart);
+        }
+        return timerElapsed;
+    }
+
+    function formatTime(ms) {
+        var totalSec = Math.floor(ms / 1000);
+        var h = Math.floor(totalSec / 3600);
+        var m = Math.floor((totalSec % 3600) / 60);
+        var s = totalSec % 60;
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        if (h > 0) {
+            return h + ':' + pad(m) + ':' + pad(s);
+        }
+        return m + ':' + pad(s);
+    }
+
+    function formatReadingTime(seconds) {
+        if (seconds < 60) return '< 1 min';
+        var mins = Math.round(seconds / 60);
+        return '~' + mins + ' min';
+    }
+
+    function timerButtonLabel() {
+        if (timerStart === null && timerElapsed === 0) return 'Start';
+        if (timerPaused) return 'Resume';
+        return 'Pause';
+    }
+
+    function updateTimerDisplay() {
+        if (notesWindow && !notesWindow.closed) {
+            var timerEl = notesWindow.document.getElementById('notesTimer');
+            if (timerEl) timerEl.textContent = formatTime(getElapsedMs());
+        }
+    }
+
+    function startTimer() {
+        timerStart = Date.now();
+        timerPaused = false;
+        timerInterval = setInterval(updateTimerDisplay, 1000);
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function pauseTimer() {
+        timerElapsed += (Date.now() - timerStart);
+        timerStart = null;
+        timerPaused = true;
+        clearInterval(timerInterval);
+        timerInterval = null;
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function toggleTimer() {
+        if (timerStart === null && !timerPaused && timerElapsed === 0) {
+            startTimer();
+        } else if (timerPaused || timerStart === null) {
+            startTimer();
+        } else {
+            pauseTimer();
+        }
+    }
+
+    function updateNotesTimerUI() {
+        if (!notesWindow || notesWindow.closed) return;
+        var btn = notesWindow.document.getElementById('notesTimerToggle');
+        if (btn) btn.textContent = timerButtonLabel();
+        var readEl = notesWindow.document.getElementById('notesReadingTime');
+        if (readEl) readEl.textContent = formatReadingTime(getReadingTime(currentSlide)) + ' read';
+        var remEl = notesWindow.document.getElementById('notesRemaining');
+        if (remEl) remEl.textContent = formatReadingTime(getRemainingReadingTime()) + ' remaining';
+    }
 
     // Get speaker notes from the DOM
     function getNotesForSlide(n) {
@@ -86,6 +204,8 @@
         if (notesWindow) {
             var title = getSlideTitleForSlide(currentSlide);
             var notes = getNotesForSlide(currentSlide);
+            var readTime = formatReadingTime(getReadingTime(currentSlide));
+            var remaining = formatReadingTime(getRemainingReadingTime());
 
             // Build notes window HTML — uses document.write because we're
             // populating a blank popup window (no XSS risk: content is from
@@ -99,6 +219,11 @@
                 '.header { background: #34495e; padding: 20px; margin: -30px -30px 30px -30px; border-bottom: 3px solid #3498db; }',
                 'h1 { color: #3498db; margin: 0; font-size: 1.8em; }',
                 '.slide-info { color: #bdc3c7; margin-top: 5px; font-size: 1.1em; }',
+                '.timer-bar { display: flex; align-items: center; gap: 16px; margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(255,255,255,0.1); }',
+                '.timer-bar .elapsed { font-family: "SF Mono", "JetBrains Mono", monospace; font-size: 1.4em; color: #2ecc71; font-weight: bold; min-width: 70px; }',
+                '.timer-bar .meta { color: #95a5a6; font-size: 0.9em; }',
+                '.timer-bar .timer-btn { background: #3498db; color: white; border: none; padding: 5px 14px; border-radius: 4px; cursor: pointer; font-size: 0.85em; font-weight: 600; }',
+                '.timer-bar .timer-btn:hover { background: #2980b9; }',
                 'h2 { color: #3498db; margin-top: 30px; margin-bottom: 15px; font-size: 1.4em; }',
                 'h3 { color: #e74c3c; margin-top: 25px; margin-bottom: 10px; font-size: 1.2em; }',
                 'p, li { font-size: 1em; line-height: 1.6; margin-bottom: 12px; }',
@@ -113,6 +238,12 @@
                 '<div class="header">',
                 '<h1 id="notesTitle">' + title + '</h1>',
                 '<div class="slide-info">Slide <span id="slideNumber">' + currentSlide + '</span> of ' + totalSlides + '</div>',
+                '<div class="timer-bar">',
+                '<span class="elapsed" id="notesTimer">' + formatTime(getElapsedMs()) + '</span>',
+                '<span class="meta" id="notesReadingTime">' + readTime + ' read</span>',
+                '<span class="meta" id="notesRemaining">' + remaining + ' remaining</span>',
+                '<button class="timer-btn" id="notesTimerToggle" onclick="window.opener.toggleTimer()">' + timerButtonLabel() + '</button>',
+                '</div>',
                 '</div>',
                 '<div class="content" id="notesContent">' + notes + '</div>',
                 '</body>',
@@ -140,6 +271,10 @@
                 contentElement.innerHTML = notes;
                 notesWindow.document.title = 'Speaker Notes - ' + title;
             }
+
+            // Update timer display and reading times
+            updateTimerDisplay();
+            updateNotesTimerUI();
         }
     }
 
@@ -155,6 +290,7 @@
         if (e.key === 'ArrowRight') changeSlide(1);
         if (e.key === 'Escape') closeNotesWindow();
         if (e.key === 'n' || e.key === 'N') openNotesWindow();
+        if (e.key === 't' || e.key === 'T') toggleTimer();
     });
 
     // Handle browser back/forward buttons
@@ -184,7 +320,9 @@
     // Expose to onclick handlers in HTML
     window.changeSlide = changeSlide;
     window.openNotesWindow = openNotesWindow;
+    window.toggleTimer = toggleTimer;
 
     // Initialize
+    computeReadingTimes();
     showSlide(currentSlide);
 })();

--- a/examples/slyds-intro/slyds.js
+++ b/examples/slyds-intro/slyds.js
@@ -8,6 +8,16 @@
     var totalSlides = document.querySelectorAll('.slide').length;
     var notesWindow = null;
 
+    // Timer state — lives in main window so closing/reopening notes preserves it
+    var timerStart = null;
+    var timerPaused = false;
+    var timerElapsed = 0;
+    var timerInterval = null;
+
+    // Reading time — computed once on load
+    var slideReadingTimes = [];
+    var WPM = 200;
+
     // Write total into counter (if element exists)
     var totalEl = document.getElementById('totalSlides');
     if (totalEl) totalEl.textContent = totalSlides;
@@ -28,6 +38,114 @@
     }
 
     var currentSlide = getSlideFromHash();
+
+    // ── Reading time computation ──
+    // Computes word count and estimated reading time for each slide's
+    // visible content (excludes speaker notes). Called once on load.
+    function computeReadingTimes() {
+        var slides = document.querySelectorAll('.slide');
+        slideReadingTimes = [];
+        slides.forEach(function (slide) {
+            var clone = slide.cloneNode(true);
+            var notes = clone.querySelector('.speaker-notes');
+            if (notes) notes.remove();
+            var text = clone.textContent || '';
+            var words = text.trim().split(/\s+/).filter(function (w) { return w.length > 0; });
+            slideReadingTimes.push(Math.ceil(words.length / WPM * 60));
+        });
+    }
+
+    // Returns reading time in seconds for slide n (1-indexed)
+    function getReadingTime(n) {
+        return slideReadingTimes[n - 1] || 0;
+    }
+
+    // Returns total remaining reading time in seconds from current slide onward
+    function getRemainingReadingTime() {
+        var total = 0;
+        for (var i = currentSlide; i < totalSlides; i++) {
+            total += (slideReadingTimes[i] || 0);
+        }
+        return total;
+    }
+
+    // ── Timer functions ──
+
+    function getElapsedMs() {
+        if (timerStart !== null && !timerPaused) {
+            return timerElapsed + (Date.now() - timerStart);
+        }
+        return timerElapsed;
+    }
+
+    function formatTime(ms) {
+        var totalSec = Math.floor(ms / 1000);
+        var h = Math.floor(totalSec / 3600);
+        var m = Math.floor((totalSec % 3600) / 60);
+        var s = totalSec % 60;
+        var pad = function (n) { return n < 10 ? '0' + n : '' + n; };
+        if (h > 0) {
+            return h + ':' + pad(m) + ':' + pad(s);
+        }
+        return m + ':' + pad(s);
+    }
+
+    function formatReadingTime(seconds) {
+        if (seconds < 60) return '< 1 min';
+        var mins = Math.round(seconds / 60);
+        return '~' + mins + ' min';
+    }
+
+    function timerButtonLabel() {
+        if (timerStart === null && timerElapsed === 0) return 'Start';
+        if (timerPaused) return 'Resume';
+        return 'Pause';
+    }
+
+    function updateTimerDisplay() {
+        if (notesWindow && !notesWindow.closed) {
+            var timerEl = notesWindow.document.getElementById('notesTimer');
+            if (timerEl) timerEl.textContent = formatTime(getElapsedMs());
+        }
+    }
+
+    function startTimer() {
+        timerStart = Date.now();
+        timerPaused = false;
+        timerInterval = setInterval(updateTimerDisplay, 1000);
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function pauseTimer() {
+        timerElapsed += (Date.now() - timerStart);
+        timerStart = null;
+        timerPaused = true;
+        clearInterval(timerInterval);
+        timerInterval = null;
+        updateTimerDisplay();
+        updateNotesTimerUI();
+    }
+
+    function toggleTimer() {
+        if (timerStart === null && !timerPaused && timerElapsed === 0) {
+            startTimer();
+        } else if (timerPaused || timerStart === null) {
+            startTimer();
+        } else {
+            pauseTimer();
+        }
+    }
+
+    function updateNotesTimerUI() {
+        if (!notesWindow || notesWindow.closed) return;
+        var btn = notesWindow.document.getElementById('notesTimerToggle');
+        if (btn) btn.textContent = timerButtonLabel();
+        var readEl = notesWindow.document.getElementById('notesReadingTime');
+        if (readEl) readEl.textContent = formatReadingTime(getReadingTime(currentSlide)) + ' read';
+        var remEl = notesWindow.document.getElementById('notesRemaining');
+        if (remEl) remEl.textContent = formatReadingTime(getRemainingReadingTime()) + ' remaining';
+    }
 
     // Get speaker notes from the DOM
     function getNotesForSlide(n) {
@@ -86,6 +204,8 @@
         if (notesWindow) {
             var title = getSlideTitleForSlide(currentSlide);
             var notes = getNotesForSlide(currentSlide);
+            var readTime = formatReadingTime(getReadingTime(currentSlide));
+            var remaining = formatReadingTime(getRemainingReadingTime());
 
             // Build notes window HTML — uses document.write because we're
             // populating a blank popup window (no XSS risk: content is from
@@ -99,6 +219,11 @@
                 '.header { background: #34495e; padding: 20px; margin: -30px -30px 30px -30px; border-bottom: 3px solid #3498db; }',
                 'h1 { color: #3498db; margin: 0; font-size: 1.8em; }',
                 '.slide-info { color: #bdc3c7; margin-top: 5px; font-size: 1.1em; }',
+                '.timer-bar { display: flex; align-items: center; gap: 16px; margin-top: 12px; padding-top: 12px; border-top: 1px solid rgba(255,255,255,0.1); }',
+                '.timer-bar .elapsed { font-family: "SF Mono", "JetBrains Mono", monospace; font-size: 1.4em; color: #2ecc71; font-weight: bold; min-width: 70px; }',
+                '.timer-bar .meta { color: #95a5a6; font-size: 0.9em; }',
+                '.timer-bar .timer-btn { background: #3498db; color: white; border: none; padding: 5px 14px; border-radius: 4px; cursor: pointer; font-size: 0.85em; font-weight: 600; }',
+                '.timer-bar .timer-btn:hover { background: #2980b9; }',
                 'h2 { color: #3498db; margin-top: 30px; margin-bottom: 15px; font-size: 1.4em; }',
                 'h3 { color: #e74c3c; margin-top: 25px; margin-bottom: 10px; font-size: 1.2em; }',
                 'p, li { font-size: 1em; line-height: 1.6; margin-bottom: 12px; }',
@@ -113,6 +238,12 @@
                 '<div class="header">',
                 '<h1 id="notesTitle">' + title + '</h1>',
                 '<div class="slide-info">Slide <span id="slideNumber">' + currentSlide + '</span> of ' + totalSlides + '</div>',
+                '<div class="timer-bar">',
+                '<span class="elapsed" id="notesTimer">' + formatTime(getElapsedMs()) + '</span>',
+                '<span class="meta" id="notesReadingTime">' + readTime + ' read</span>',
+                '<span class="meta" id="notesRemaining">' + remaining + ' remaining</span>',
+                '<button class="timer-btn" id="notesTimerToggle" onclick="window.opener.toggleTimer()">' + timerButtonLabel() + '</button>',
+                '</div>',
                 '</div>',
                 '<div class="content" id="notesContent">' + notes + '</div>',
                 '</body>',
@@ -140,6 +271,10 @@
                 contentElement.innerHTML = notes;
                 notesWindow.document.title = 'Speaker Notes - ' + title;
             }
+
+            // Update timer display and reading times
+            updateTimerDisplay();
+            updateNotesTimerUI();
         }
     }
 
@@ -155,6 +290,7 @@
         if (e.key === 'ArrowRight') changeSlide(1);
         if (e.key === 'Escape') closeNotesWindow();
         if (e.key === 'n' || e.key === 'N') openNotesWindow();
+        if (e.key === 't' || e.key === 'T') toggleTimer();
     });
 
     // Handle browser back/forward buttons
@@ -184,7 +320,9 @@
     // Expose to onclick handlers in HTML
     window.changeSlide = changeSlide;
     window.openNotesWindow = openNotesWindow;
+    window.toggleTimer = toggleTimer;
 
     // Initialize
+    computeReadingTimes();
     showSlide(currentSlide);
 })();

--- a/internal/builder/timer_test.go
+++ b/internal/builder/timer_test.go
@@ -1,0 +1,109 @@
+package builder
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/panyam/slyds/internal/scaffold"
+)
+
+// scaffoldAndBuild creates a test presentation in a temp directory, builds it,
+// and returns the built HTML string. Fails the test on any error.
+func scaffoldAndBuild(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(origDir)
+
+	slug, err := scaffold.Create("Timer Test", 4)
+	if err != nil {
+		t.Fatalf("scaffold.Create failed: %v", err)
+	}
+	root := filepath.Join(tmp, slug)
+
+	result, err := Build(root)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	return result.HTML
+}
+
+// TestBuildContainsTimerFeatures verifies that built presentations include
+// the core timer functions (toggleTimer, startTimer, pauseTimer, formatTime,
+// getElapsedMs) in the inlined JavaScript output. These functions power the
+// elapsed presentation timer in the speaker notes window.
+func TestBuildContainsTimerFeatures(t *testing.T) {
+	html := scaffoldAndBuild(t)
+
+	timerFunctions := []string{
+		"toggleTimer",
+		"startTimer",
+		"pauseTimer",
+		"formatTime",
+		"getElapsedMs",
+	}
+
+	for _, fn := range timerFunctions {
+		if !strings.Contains(html, fn) {
+			t.Errorf("built HTML missing timer function: %s", fn)
+		}
+	}
+}
+
+// TestBuildContainsNotesTimerUI verifies that the speaker notes window HTML
+// builder includes timer display elements: the elapsed time display
+// (notesTimer), per-slide reading time (notesReadingTime), remaining deck
+// time (notesRemaining), and the start/pause toggle button (notesTimerToggle).
+func TestBuildContainsNotesTimerUI(t *testing.T) {
+	html := scaffoldAndBuild(t)
+
+	uiElements := []string{
+		"notesTimer",
+		"notesReadingTime",
+		"notesRemaining",
+		"notesTimerToggle",
+		"timer-bar",
+	}
+
+	for _, el := range uiElements {
+		if !strings.Contains(html, el) {
+			t.Errorf("built HTML missing notes timer UI element: %s", el)
+		}
+	}
+}
+
+// TestBuildTimerKeyboardShortcut verifies that the T key is registered as a
+// keyboard shortcut for toggling the presentation timer. The handler should
+// call toggleTimer() on both 't' and 'T' key presses.
+func TestBuildTimerKeyboardShortcut(t *testing.T) {
+	html := scaffoldAndBuild(t)
+
+	if !strings.Contains(html, "e.key === 't'") && !strings.Contains(html, `e.key === 'T'`) {
+		t.Error("built HTML missing T key handler for timer toggle")
+	}
+}
+
+// TestBuildReadingTimeComputation verifies that the reading time computation
+// function (computeReadingTimes) is present in the built output. This function
+// calculates per-slide word counts at page load, excluding speaker notes
+// content, and converts to estimated reading time at 200 words per minute.
+func TestBuildReadingTimeComputation(t *testing.T) {
+	html := scaffoldAndBuild(t)
+
+	readingTimeFunctions := []string{
+		"computeReadingTimes",
+		"slideReadingTimes",
+		"getReadingTime",
+		"getRemainingReadingTime",
+		"formatReadingTime",
+	}
+
+	for _, fn := range readingTimeFunctions {
+		if !strings.Contains(html, fn) {
+			t.Errorf("built HTML missing reading time function: %s", fn)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **Elapsed timer** in speaker notes window — toggle with `T` key or button in notes popup
- **Per-slide reading time** estimate at ~200 WPM (excludes speaker notes content)
- **Remaining deck time** — sum of reading times for slides ahead
- Timer state persists across notes window close/reopen (state lives in main window)
- All UI in the notes popup only — main slide view stays clean for screen sharing

Closes #22 (Phase 1)

## Test plan
- [x] `go test ./...` — all tests pass (4 new timer tests + 1 examples timer test)
- [x] `make examples` — builds all 3 decks
- [x] Open any example → press `N` for notes → see timer bar with 0:00, reading time, remaining time
- [x] Press `T` → timer starts counting, button shows "Pause"
- [x] Navigate slides → reading time and remaining time update per slide
- [x] Press `T` again → timer pauses, button shows "Resume"
- [x] Close notes window, reopen → timer still running at correct elapsed time