### PR TITLE
feat: Workspace abstraction for MCP server (#74 PR 1/4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -127,9 +127,20 @@ This is the approved path for all programmatic slide content access. Regex-based
 
 ## MCP and agent-facing surfaces
 
-The CLI exposes machine-readable **`slyds introspect`** (layouts, themes, command catalog) and per-deck **`slyds describe`** for non-MCP agents.
+The CLI exposes machine-readable **`slyds introspect`** (layouts, themes, command catalog), per-deck **`slyds describe`**, and **`slyds ws info` / `slyds ws list`** for inspecting the MCP workspace without starting a server.
 
-**Model Context Protocol** (`cmd/mcp.go`, `cmd/mcp_tools.go`, `cmd/mcp_resources.go`, `cmd/mcp_apps.go`): uses **mcpkit** v0.1.15 (split packages: `core/`, `server/`) + **ext/ui** v0.1.15 (MCP Apps). Single-struct registration (`srv.Register`), per-tool timeouts, `StructuredResult` for typed output, error handler for session lifecycle, EventStore for Streamable HTTP reconnection. Exposes **13 tools** (11 core + 2 preview) and **7 browsable resources** for reading deck content. Transports: Streamable HTTP (default), SSE (`--sse`), or stdio (`--stdio`). `--deck-root` sets the directory where decks are discovered. See [docs/MCP.md](docs/MCP.md).
+### Workspace layer
+
+MCP tool and resource handlers never touch raw filesystem paths. They resolve decks through a `Workspace` interface (`cmd/workspace.go`). The `LocalWorkspace` implementation is a thin wrapper around `core.OpenDeckDir` rooted at `--deck-root`. A workspace middleware installs the active `Workspace` into every request's `context.Context`, and handlers call `workspaceFromContext(ctx).OpenDeck(name)` to get a `*core.Deck`.
+
+The abstraction exists so that:
+- a future hosted deployment can resolve a per-request `Workspace` from an authenticated session instead of a single startup-constructed one, without changing tool/resource handler code
+- deck names with path separators (`../escape`, `root/sub`) are rejected at the API boundary, reserving `/` for future multi-root workspace qualification
+- unit tests can install a workspace directly via `withWorkspace(ctx, ws)` without going through the full middleware chain
+
+The `slyds ws` CLI subcommand exercises the same `LocalWorkspace` implementation the MCP server uses, making it a single-process smoke test for the wiring.
+
+**Model Context Protocol** (`cmd/mcp.go`, `cmd/mcp_tools.go`, `cmd/mcp_resources.go`, `cmd/mcp_apps.go`): uses **mcpkit** v0.1.15 (split packages: `core/`, `server/`) + **ext/ui** v0.1.15 (MCP Apps). Single-struct registration (`srv.Register`), workspace middleware, per-tool timeouts, `StructuredResult` for typed output, error handler for session lifecycle, EventStore for Streamable HTTP reconnection. Exposes **13 tools** (11 core + 2 preview) and **7 browsable resources** for reading deck content. Transports: Streamable HTTP (default), SSE (`--sse`), or stdio (`--stdio`). `--deck-root` sets the local workspace root. See [docs/MCP.md](docs/MCP.md).
 
 **Tools**: `list_decks`, `create_deck`, `describe_deck`, `list_slides`, `read_slide`, `edit_slide`, `query_slide`, `add_slide`, `remove_slide`, `check_deck`, `build_deck`, `preview_deck`, `preview_slide`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ make audit       # govulncheck + gosec + gitleaks
 - `examples/` — demo presentations with tests.
 - `docs/` — MCP setup, agent themes, CSS contract, design docs.
 
-Key files: `core/deck.go` (Deck API), `core/osfs.go` (OS boundary), `cmd/mcp.go` (MCP server), `cmd/mcp_tools.go` (11 semantic tools), `cmd/mcp_resources.go` (7 browsable resources).
+Key files: `core/deck.go` (Deck API), `core/osfs.go` (OS boundary), `cmd/workspace.go` (Workspace abstraction), `cmd/mcp.go` (MCP server), `cmd/mcp_tools.go` (11 semantic tools), `cmd/mcp_resources.go` (7 browsable resources), `cmd/ws.go` (`slyds ws` debug CLI).
 
 ## FS Abstraction
 
@@ -33,6 +33,7 @@ All Deck I/O goes through `templar.WritableFS` (v0.1.0). No `os.*`/`filepath.*` 
 ## Conventions
 
 - **Deck is the single API** — cmd/ calls Deck methods, never touches FS internals
+- **Workspace is the MCP boundary** — MCP tool and resource handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`, never from raw paths. The workspace is installed on every request via `workspaceMiddleware`. See [cmd/workspace.go](cmd/workspace.go).
 - **No hardcoded HTML** — use embedded `.tmpl` files under `assets/templates/`
 - **No regex HTML mutation** — use `d.Query()` (goquery/CSS selectors). See [CONSTRAINTS.md](CONSTRAINTS.md)
 - **Index.html is source of truth** for slide ordering
@@ -43,8 +44,8 @@ All Deck I/O goes through `templar.WritableFS` (v0.1.0). No `os.*`/`filepath.*` 
 - **macOS /private symlinks**: temp dirs resolve `/var/...` vs `/private/var/...`. Don't compare paths in tests.
 - **`go:embed` paths relative to Go file** — `assets/embed.go` lives alongside the embedded files; `core/embed.go` re-exports.
 - **Theme render fallback** — `InsertSlide` uses layout system first; falls back to theme templates.
-- **MCP** — 13 tools (11 core + 2 preview) + 7 resources via mcpkit v0.1.15 (split packages: `core/`, `server/`, `ext/ui`). Single-struct registration (`srv.Register`). Per-tool timeouts on `build_deck` (30s) and `check_deck` (10s). `StructuredResult` for typed tool output. Error handler for session lifecycle logging. EventStore for Streamable HTTP reconnection. Transports: Streamable HTTP, SSE, stdio. MCP Apps extension for inline slide previews. See [docs/MCP.md](docs/MCP.md). `--deck-root` sets discovery root.
-- **CLI-direct agent mode** — `describe --json`, `ls --json`, `check --json`, `build --json` for agents using shell commands instead of MCP. See [AGENT-SETUP.md](AGENT-SETUP.md).
+- **MCP** — 13 tools (11 core + 2 preview) + 7 resources via mcpkit v0.1.15 (split packages: `core/`, `server/`, `ext/ui`). Single-struct registration (`srv.Register`). Workspace middleware injects a `Workspace` into every request's context; handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`. Per-tool timeouts on `build_deck` (30s) and `check_deck` (10s). `StructuredResult` for typed tool output. Error handler for session lifecycle logging. EventStore for Streamable HTTP reconnection. Transports: Streamable HTTP, SSE, stdio. MCP Apps extension for inline slide previews. See [docs/MCP.md](docs/MCP.md). `--deck-root` sets the local workspace root.
+- **CLI-direct agent mode** — `describe --json`, `ls --json`, `check --json`, `build --json`, `ws info --json`, `ws list --json` for agents using shell commands instead of MCP. See [AGENT-SETUP.md](AGENT-SETUP.md).
 - **`SLYDS_MCP_TOKEN`** env var — fallback for `--token` flag in container/CI deployments.
 
 ## Stack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ All Deck I/O goes through `templar.WritableFS` (v0.1.0). No `os.*`/`filepath.*` 
 - **MCP** — 13 tools (11 core + 2 preview) + 7 resources via mcpkit v0.1.15 (split packages: `core/`, `server/`, `ext/ui`). Single-struct registration (`srv.Register`). Workspace middleware injects a `Workspace` into every request's context; handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`. Per-tool timeouts on `build_deck` (30s) and `check_deck` (10s). `StructuredResult` for typed tool output. Error handler for session lifecycle logging. EventStore for Streamable HTTP reconnection. Transports: Streamable HTTP, SSE, stdio. MCP Apps extension for inline slide previews. See [docs/MCP.md](docs/MCP.md). `--deck-root` sets the local workspace root.
 - **CLI-direct agent mode** — `describe --json`, `ls --json`, `check --json`, `build --json`, `ws info --json`, `ws list --json` for agents using shell commands instead of MCP. See [AGENT-SETUP.md](AGENT-SETUP.md).
 - **`SLYDS_MCP_TOKEN`** env var — fallback for `--token` flag in container/CI deployments.
+- **`SLYDS_DECK_ROOT`** env var — fallback for `--deck-root` flag on both `slyds mcp` and `slyds ws`. Precedence: explicit flag > env var > `.` (cwd).
 
 ## Stack
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build setup-tools install test clean version examples examples-serve gh-pages \
-       demo dev-http dev-sse dev-stdio dev-http-auth dev-sse-auth tunnel
+       demo demo-smoke dev-http dev-sse dev-stdio dev-http-auth dev-sse-auth tunnel
 
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 LDFLAGS := -X github.com/panyam/slyds/cmd.Version=$(VERSION)
@@ -93,6 +93,46 @@ demo: build
 	@echo "  getting-started/   (3 slides, default theme)"
 	@echo "  dark-mode-talk/    (5 slides, dark theme)"
 	@echo "  corporate-review/  (4 slides, corporate theme)"
+
+# Smoke test: exercise the Workspace layer end-to-end without starting a
+# server. First checks `slyds ws info` and `slyds ws list`, then starts a
+# real MCP server in the background, calls list_decks via curl/JSON-RPC,
+# and tears everything down. Verifies both the CLI workspace path and the
+# MCP middleware path resolve the same decks.
+demo-smoke: demo
+	@set -e; \
+	echo "== slyds ws info =="; \
+	$(CURDIR)/slyds ws info --deck-root $(DEMO_DIR); \
+	echo ""; \
+	echo "== slyds ws list =="; \
+	$(CURDIR)/slyds ws list --deck-root $(DEMO_DIR); \
+	echo ""; \
+	echo "== slyds ws list --json =="; \
+	$(CURDIR)/slyds ws list --deck-root $(DEMO_DIR) --json; \
+	echo ""; \
+	echo "== starting slyds mcp (http) =="; \
+	$(CURDIR)/slyds mcp --listen 127.0.0.1:6275 --deck-root $(DEMO_DIR) > /tmp/slyds-smoke.log 2>&1 & \
+	SRV_PID=$$!; \
+	trap "kill $$SRV_PID 2>/dev/null; rm -f /tmp/slyds-smoke.log" EXIT; \
+	sleep 1; \
+	echo "== initialize session =="; \
+	RESP=$$(curl -s -i -X POST http://127.0.0.1:6275/mcp \
+	  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"smoke","version":"1"}}}'); \
+	SESSION=$$(printf '%s' "$$RESP" | awk -F': ' 'tolower($$1)=="mcp-session-id"{gsub(/[\r\n]/,"",$$2); print $$2}'); \
+	if [ -z "$$SESSION" ]; then echo "FAIL: no session id from initialize"; echo "$$RESP"; exit 1; fi; \
+	echo "session: $$SESSION"; \
+	curl -s -X POST http://127.0.0.1:6275/mcp \
+	  -H "Mcp-Session-Id: $$SESSION" -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' > /dev/null; \
+	echo "== tools/call list_decks =="; \
+	CALL=$$(curl -s -X POST http://127.0.0.1:6275/mcp \
+	  -H "Mcp-Session-Id: $$SESSION" -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_decks","arguments":{}}}'); \
+	echo "$$CALL"; \
+	echo "$$CALL" | grep -q 'getting-started' || { echo "FAIL: list_decks missing getting-started"; exit 1; }; \
+	echo ""; \
+	echo "OK — CLI ws and MCP list_decks agree on deck set."
 
 # Dev: Streamable HTTP on :$(SLYDS_MCP_PORT)
 dev-http: demo

--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -42,6 +42,10 @@
 - [x] ~~Agent skills scaffolding — `slyds init` generates .claude/skills/ with /slyds-preview, /slyds-check, /slyds-slides, /slyds-build, /slyds-add-slide (#67)~~
 - [x] ~~MCP Apps — inline slide previews via `preview_deck` and `preview_slide` tools (#64)~~
 - [x] ~~mcpkit v0.1.15 adoption — single-struct registration, per-tool timeouts, StructuredResult, error handler, EventStore (#71)~~
+- [x] ~~Workspace abstraction — `cmd/workspace.go`, `slyds ws` CLI, MCP middleware-based deck resolution (#74, PR 1 of 4)~~
+- [ ] Slug-as-ID in MCP tools + slug uniqueness (#74 subtask)
+- [ ] Optimistic versioning on MCP mutations (#74 subtask)
+- [ ] Multi-root workspace.yaml config (#74 subtask)
 - [ ] Slide folders with co-located assets (e.g., `slides/03-architecture/slide.html` + `diagram.png`)
 - [ ] Live reload on file changes during `slyds serve`
 - [ ] Theme composability via templar `extend`/`namespace` directives

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,9 @@ Added MCP Apps extension (`io.modelcontextprotocol/ui`) with two preview tools: 
 ## Phase 9g — mcpkit v0.1.15 adoption (done)
 Adopted mcpkit v0.1.15 features: single-struct registration (`srv.Register` with `server.Tool`/`server.Resource`/`server.ResourceTemplate`), per-tool timeouts (`build_deck` 30s, `check_deck` 10s), `StructuredResult` for typed tool output, `ToolCallTyped` in E2E tests, `ErrorHandler` for session lifecycle logging, `EventStore` for Streamable HTTP reconnection. Typed result structs replace `map[string]any` in tool handlers. No behavioral changes — purely internal improvements.
 
+## Phase 9h — Workspace abstraction (done)
+Introduced a `Workspace` interface (`cmd/workspace.go`) to decouple MCP tool and resource handlers from raw `--deck-root` filesystem paths. The `LocalWorkspace` implementation is installed on every MCP request via `workspaceMiddleware`; handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`. New `slyds ws` CLI subcommand (`ws info`, `ws list`) exercises the same workspace path as the MCP server, and `make demo-smoke` drives both through a single end-to-end test. This is the prep refactor for hosted multi-tenancy (#76), optimistic concurrency, and slug-as-ID slide identity — all tracked as follow-ups under #74. No behavioral changes for existing agents or CLI users.
+
 ## Phase 10 — Slide Folders
 Support `slides/03-name/slide.html` with co-located assets (images, per-slide CSS). Auto-detect folder vs file slides.
 

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 
 	mcpcore "github.com/panyam/mcpkit/core"
@@ -17,7 +16,6 @@ import (
 	"github.com/panyam/mcpkit/server"
 	gohttp "github.com/panyam/servicekit/http"
 	"github.com/panyam/slyds/assets"
-	"github.com/panyam/slyds/core"
 	"github.com/spf13/cobra"
 )
 
@@ -56,11 +54,14 @@ func init() {
 }
 
 func runMCPServer() error {
-	// Resolve deck root to absolute path
-	root, err := filepath.Abs(mcpDeckRoot)
+	// Build a LocalWorkspace rooted at --deck-root. In a future hosted
+	// deployment, the workspace is built per request from auth; here it's
+	// a single constant installed via middleware below.
+	ws, err := NewLocalWorkspace(mcpDeckRoot)
 	if err != nil {
 		return fmt.Errorf("invalid deck-root: %w", err)
 	}
+	root := ws.Root()
 
 	// Token from env if flag not set
 	mcpToken = resolveMCPToken(mcpToken)
@@ -70,6 +71,7 @@ func runMCPServer() error {
 	serverOpts = append(serverOpts, server.WithListen(mcpListen))
 	serverOpts = append(serverOpts, server.WithExtension(ui.UIExtension{}))
 	serverOpts = append(serverOpts, server.WithErrorHandler(&slydsMCPErrorHandler{}))
+	serverOpts = append(serverOpts, server.WithMiddleware(workspaceMiddleware(ws)))
 	if mcpToken != "" {
 		serverOpts = append(serverOpts, server.WithBearerToken(mcpToken))
 	}
@@ -82,10 +84,11 @@ func runMCPServer() error {
 		serverOpts...,
 	)
 
-	// Register resources, tools, and app previews
-	registerResources(srv, root)
-	registerTools(srv, root)
-	registerAppTools(srv, root)
+	// Register resources, tools, and app previews. None of these capture
+	// the workspace directly — handlers resolve it from request context.
+	registerResources(srv)
+	registerTools(srv)
+	registerAppTools(srv)
 
 	// Transport selection
 	if mcpUseStdio {
@@ -117,10 +120,15 @@ func runMCPServer() error {
 		transport = "Streamable HTTP"
 	}
 
-	// Build MCP handler and wrap with landing page at /
+	// Build MCP handler and wrap with landing page at /. The landing page
+	// needs deck names up front; we call ws.ListDecks() once at startup.
 	mcpHandler := srv.Handler(transportOpts...)
-	decks := discoverDecks(root)
-	handler := mcpWithLanding(mcpHandler, transport, mcpListen, decks, mcpToken != "")
+	deckRefs, _ := ws.ListDecks()
+	deckNames := make([]string, 0, len(deckRefs))
+	for _, r := range deckRefs {
+		deckNames = append(deckNames, r.Name)
+	}
+	handler := mcpWithLanding(mcpHandler, transport, mcpListen, deckNames, mcpToken != "")
 
 	fmt.Fprintf(os.Stderr, "MCP server (%s) on %s — deck root: %s\n", transport, mcpListen, root)
 	if mcpToken != "" {
@@ -135,32 +143,6 @@ func runMCPServer() error {
 		WriteTimeout: 0, // SSE requires no write timeout
 	}
 	return listenAndServeGraceful(httpSrv)
-}
-
-// discoverDecks finds all deck directories under root.
-// A deck is a directory containing index.html.
-func discoverDecks(root string) []string {
-	var decks []string
-
-	// Check if root itself is a deck
-	if _, err := os.Stat(filepath.Join(root, "index.html")); err == nil {
-		decks = append(decks, ".")
-	}
-
-	// Check subdirectories
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return decks
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(root, e.Name(), "index.html")); err == nil {
-			decks = append(decks, e.Name())
-		}
-	}
-	return decks
 }
 
 // resolveMCPToken returns the token from the flag value, falling back to the
@@ -310,13 +292,3 @@ func (h *slydsMCPErrorHandler) OnKeepaliveFailure(sessionID string, consecutiveF
 	fmt.Fprintf(os.Stderr, "MCP keepalive failure: session=%s failures=%d\n", sessionID, consecutiveFailures)
 }
 
-// openDeck resolves a deck name to a Deck instance.
-func openDeck(root, name string) (*core.Deck, error) {
-	var dir string
-	if name == "." || name == "" {
-		dir = root
-	} else {
-		dir = filepath.Join(root, name)
-	}
-	return core.OpenDeckDir(dir)
-}

--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -49,15 +49,16 @@ func init() {
 	mcpCmd.Flags().StringVar(&mcpPublicURL, "public-url", "", "Public URL for reverse proxy")
 	mcpCmd.Flags().BoolVar(&mcpUseSSE, "sse", false, "Use legacy HTTP+SSE transport")
 	mcpCmd.Flags().BoolVar(&mcpUseStdio, "stdio", false, "Use stdio transport (Content-Length framed JSON-RPC on stdin/stdout)")
-	mcpCmd.Flags().StringVar(&mcpDeckRoot, "deck-root", ".", "Root directory for deck discovery")
+	mcpCmd.Flags().StringVar(&mcpDeckRoot, "deck-root", "", "Root directory for deck discovery (default: $SLYDS_DECK_ROOT, or current directory)")
 	rootCmd.AddCommand(mcpCmd)
 }
 
 func runMCPServer() error {
-	// Build a LocalWorkspace rooted at --deck-root. In a future hosted
-	// deployment, the workspace is built per request from auth; here it's
-	// a single constant installed via middleware below.
-	ws, err := NewLocalWorkspace(mcpDeckRoot)
+	// Build a LocalWorkspace rooted at --deck-root (falling back to
+	// SLYDS_DECK_ROOT env var, then "."). In a future hosted deployment,
+	// the workspace is built per request from auth; here it's a single
+	// constant installed via middleware below.
+	ws, err := NewLocalWorkspace(resolveDeckRoot(mcpDeckRoot))
 	if err != nil {
 		return fmt.Errorf("invalid deck-root: %w", err)
 	}
@@ -152,6 +153,20 @@ func resolveMCPToken(flagValue string) string {
 		return flagValue
 	}
 	return os.Getenv("SLYDS_MCP_TOKEN")
+}
+
+// resolveDeckRoot returns the workspace root in precedence order:
+// explicit --deck-root flag → SLYDS_DECK_ROOT environment variable →
+// current working directory ("."). Shared by `slyds mcp` and `slyds ws`
+// so the fallback behavior is identical across commands.
+func resolveDeckRoot(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if env := os.Getenv("SLYDS_DECK_ROOT"); env != "" {
+		return env
+	}
+	return "."
 }
 
 // maskToken returns a redacted version of a token, showing only the first 2

--- a/cmd/mcp_apps.go
+++ b/cmd/mcp_apps.go
@@ -70,8 +70,10 @@ func injectInitialSlide(html string, position int) (string, error) {
 }
 
 // registerAppTools registers MCP Apps (UI extension) tools that render
-// slide previews as inline HTML iframes in LLM hosts.
-func registerAppTools(srv *server.Server, root string) {
+// slide previews as inline HTML iframes in LLM hosts. Handlers resolve the
+// active Workspace from request context so the same registration works
+// for localhost and future hosted deployments.
+func registerAppTools(srv *server.Server) {
 	// preview_deck — full navigable presentation
 	ui.RegisterAppTool(srv, ui.AppToolConfig{
 		Name:        "preview_deck",
@@ -79,7 +81,7 @@ func registerAppTools(srv *server.Server, root string) {
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"deck": propString("Deck name (subdirectory under deck root)"),
+				"deck": propString("Deck name (workspace-scoped identifier)"),
 			},
 			"required": []string{"deck"},
 		},
@@ -91,9 +93,9 @@ func registerAppTools(srv *server.Server, root string) {
 			if err := req.Bind(&p); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			result, err := buildDeckForPreview(d)
 			if err != nil {
@@ -135,7 +137,7 @@ func registerAppTools(srv *server.Server, root string) {
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{
-				"deck":     propString("Deck name (subdirectory under deck root)"),
+				"deck":     propString("Deck name (workspace-scoped identifier)"),
 				"position": propInt("Slide position (1-based)"),
 			},
 			"required": []string{"deck", "position"},
@@ -149,9 +151,9 @@ func registerAppTools(srv *server.Server, root string) {
 			if err := req.Bind(&p); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			// Validate position against the deck's slide list. This also
 			// lets us surface a helpful "out of range" error before spending

--- a/cmd/mcp_apps_test.go
+++ b/cmd/mcp_apps_test.go
@@ -20,13 +20,18 @@ import (
 // automatic httptest server lifecycle, session management, and t.Fatal on errors.
 func newSlydsMCPClientWithUI(t *testing.T, root string) *testutil.TestClient {
 	t.Helper()
+	ws, err := NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
 	srv := server.NewServer(
 		mcpcore.ServerInfo{Name: "slyds-test", Version: "0.0.1"},
 		server.WithExtension(ui.UIExtension{}),
+		server.WithMiddleware(workspaceMiddleware(ws)),
 	)
-	registerResources(srv, root)
-	registerTools(srv, root)
-	registerAppTools(srv, root)
+	registerResources(srv)
+	registerTools(srv)
+	registerAppTools(srv)
 	return testutil.NewTestClient(t, srv)
 }
 
@@ -38,7 +43,7 @@ func TestPreviewDeckReturnsHTML(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Preview Deck", "default", 3)
 
 	_, handler := previewDeckToolParts(root)
-	result := callTool(t, handler, map[string]string{"deck": "test-deck"})
+	result := callTool(t, root, handler, map[string]string{"deck": "test-deck"})
 	if result.IsError {
 		t.Fatalf("preview_deck error: %s", toolText(result))
 	}
@@ -74,7 +79,7 @@ func TestPreviewSlideReturnsHTML(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Slide Preview", "dark", 3)
 
 	_, handler := previewSlideToolParts(root)
-	result := callTool(t, handler, map[string]any{"deck": "test-deck", "position": 2})
+	result := callTool(t, root, handler, map[string]any{"deck": "test-deck", "position": 2})
 	if result.IsError {
 		t.Fatalf("preview_slide error: %s", toolText(result))
 	}
@@ -118,7 +123,7 @@ func TestPreviewSlideInvalidPosition(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Error Test", "default", 3)
 
 	_, handler := previewSlideToolParts(root)
-	result := callTool(t, handler, map[string]any{"deck": "test-deck", "position": 99})
+	result := callTool(t, root, handler, map[string]any{"deck": "test-deck", "position": 99})
 	if !result.IsError {
 		t.Error("expected error for invalid slide position")
 	}
@@ -129,7 +134,7 @@ func TestPreviewSlideZeroPosition(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Zero Test", "default", 3)
 
 	_, handler := previewSlideToolParts(root)
-	result := callTool(t, handler, map[string]any{"deck": "test-deck", "position": 0})
+	result := callTool(t, root, handler, map[string]any{"deck": "test-deck", "position": 0})
 	if !result.IsError {
 		t.Error("expected error for position 0")
 	}
@@ -145,10 +150,10 @@ func TestPreviewSlideMatchesPreviewDeck(t *testing.T) {
 	_, deckHandler := previewDeckToolParts(root)
 	_, slideHandler := previewSlideToolParts(root)
 
-	if r := callTool(t, deckHandler, map[string]string{"deck": "parity"}); r.IsError {
+	if r := callTool(t, root, deckHandler, map[string]string{"deck": "parity"}); r.IsError {
 		t.Fatalf("preview_deck: %s", toolText(r))
 	}
-	if r := callTool(t, slideHandler, map[string]any{"deck": "parity", "position": 3}); r.IsError {
+	if r := callTool(t, root, slideHandler, map[string]any{"deck": "parity", "position": 3}); r.IsError {
 		t.Fatalf("preview_slide: %s", toolText(r))
 	}
 
@@ -281,11 +286,16 @@ func previewSlideToolParts(root string) (mcpcore.ToolDef, mcpcore.ToolHandler) {
 }
 
 func extractAppTool(root, name string) (mcpcore.ToolDef, mcpcore.ToolHandler) {
+	ws, err := NewLocalWorkspace(root)
+	if err != nil {
+		panic(fmt.Sprintf("NewLocalWorkspace: %v", err))
+	}
 	srv := server.NewServer(
 		mcpcore.ServerInfo{Name: "test", Version: "0.0.1"},
 		server.WithExtension(ui.UIExtension{}),
+		server.WithMiddleware(workspaceMiddleware(ws)),
 	)
-	registerAppTools(srv, root)
+	registerAppTools(srv)
 
 	// Use tools/list to find the tool definition
 	req := &mcpcore.Request{

--- a/cmd/mcp_e2e_test.go
+++ b/cmd/mcp_e2e_test.go
@@ -68,9 +68,16 @@ func toolCallTyped[T any](t *testing.T, tc *testutil.TestClient, name string, ar
 // server lifecycle, session management, and t.Fatal on errors.
 func newSlydsMCPClient(t *testing.T, root string) *testutil.TestClient {
 	t.Helper()
-	srv := server.NewServer(mcpcore.ServerInfo{Name: "slyds-test", Version: "0.0.1"})
-	registerResources(srv, root)
-	registerTools(srv, root)
+	ws, err := NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	srv := server.NewServer(
+		mcpcore.ServerInfo{Name: "slyds-test", Version: "0.0.1"},
+		server.WithMiddleware(workspaceMiddleware(ws)),
+	)
+	registerResources(srv)
+	registerTools(srv)
 	return testutil.NewTestClient(t, srv)
 }
 
@@ -331,20 +338,18 @@ func TestE2E_ToolCallTyped(t *testing.T) {
 // only (json:"-"), so this is a unit test inspecting the struct directly
 // rather than an E2E test via tools/list.
 func TestPerToolTimeout(t *testing.T) {
-	root := t.TempDir()
-
-	build := buildDeckTool(root)
+	build := buildDeckTool()
 	if build.Timeout != 30*time.Second {
 		t.Errorf("build_deck timeout = %v, want 30s", build.Timeout)
 	}
 
-	check := checkDeckTool(root)
+	check := checkDeckTool()
 	if check.Timeout != 10*time.Second {
 		t.Errorf("check_deck timeout = %v, want 10s", check.Timeout)
 	}
 
 	// Other tools should have no per-tool timeout (use server default)
-	list := listDecksTool(root)
+	list := listDecksTool()
 	if list.Timeout != 0 {
 		t.Errorf("list_decks timeout = %v, want 0 (server default)", list.Timeout)
 	}
@@ -362,9 +367,16 @@ func TestE2E_StdioTransport(t *testing.T) {
 	root := t.TempDir()
 	core.CreateInDir("Stdio Test", 2, "default", fmt.Sprintf("%s/test-deck", root), true)
 
-	srv := server.NewServer(mcpcore.ServerInfo{Name: "slyds-stdio", Version: "0.0.1"})
-	registerResources(srv, root)
-	registerTools(srv, root)
+	ws, err := NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	srv := server.NewServer(
+		mcpcore.ServerInfo{Name: "slyds-stdio", Version: "0.0.1"},
+		server.WithMiddleware(workspaceMiddleware(ws)),
+	)
+	registerResources(srv)
+	registerTools(srv)
 
 	// Create pipe pairs: server reads from sr, client writes to cw;
 	// client reads from cr, server writes to sw.

--- a/cmd/mcp_resources.go
+++ b/cmd/mcp_resources.go
@@ -12,23 +12,28 @@ import (
 )
 
 // registerResources registers all MCP resources on the server using
-// single-struct registration (mcpkit v0.1.15).
-func registerResources(srv *server.Server, root string) {
+// single-struct registration (mcpkit v0.1.15). Every handler resolves the
+// active Workspace from request context, matching the tool-handler pattern.
+// This keeps localhost and future hosted deployments on the same code path.
+func registerResources(srv *server.Server) {
 	srv.Register(
 		// Static: server info
 		server.Resource{
 			ResourceDef: mcpcore.ResourceDef{
 				URI:         "slyds://server/info",
 				Name:        "Server Info",
-				Description: "slyds MCP server version, capabilities, and deck root",
+				Description: "slyds MCP server version, capabilities, and workspace root",
 				MimeType:    "application/json",
 			},
 			Handler: func(ctx context.Context, req mcpcore.ResourceRequest) (mcpcore.ResourceResult, error) {
+				ws := workspaceFromContext(ctx)
 				info := map[string]any{
-					"name":      "slyds",
-					"version":   Version,
-					"deck_root": root,
-					"themes":    core.AvailableThemeNames(),
+					"name":    "slyds",
+					"version": Version,
+					"themes":  core.AvailableThemeNames(),
+				}
+				if lw, ok := ws.(*LocalWorkspace); ok {
+					info["deck_root"] = lw.Root()
 				}
 				layouts, _ := core.ListLayouts()
 				info["layouts"] = layouts
@@ -48,20 +53,27 @@ func registerResources(srv *server.Server, root string) {
 			ResourceTemplate: mcpcore.ResourceTemplate{
 				URITemplate: "slyds://decks",
 				Name:        "Deck List",
-				Description: "List all presentation decks found under the deck root",
+				Description: "List all presentation decks visible to the current workspace",
 				MimeType:    "application/json",
 			},
 			Handler: func(ctx context.Context, uri string, params map[string]string) (mcpcore.ResourceResult, error) {
-				names := discoverDecks(root)
+				ws := workspaceFromContext(ctx)
+				if ws == nil {
+					return mcpcore.ResourceResult{}, fmt.Errorf("internal: no workspace on context")
+				}
+				refs, err := ws.ListDecks()
+				if err != nil {
+					return mcpcore.ResourceResult{}, err
+				}
 				var decks []deckSummary
-				for _, name := range names {
-					d, err := openDeck(root, name)
+				for _, ref := range refs {
+					d, err := ws.OpenDeck(ref.Name)
 					if err != nil {
 						continue
 					}
 					count, _ := d.SlideCount()
 					decks = append(decks, deckSummary{
-						Name:   name,
+						Name:   ref.Name,
 						Title:  d.Title(),
 						Theme:  d.Theme(),
 						Slides: count,
@@ -87,9 +99,9 @@ func registerResources(srv *server.Server, root string) {
 				MimeType:    "application/json",
 			},
 			Handler: func(ctx context.Context, uri string, params map[string]string) (mcpcore.ResourceResult, error) {
-				d, err := openDeck(root, params["name"])
+				d, err := openDeckForResource(ctx, params["name"])
 				if err != nil {
-					return mcpcore.ResourceResult{}, fmt.Errorf("deck %q not found: %w", params["name"], err)
+					return mcpcore.ResourceResult{}, err
 				}
 				desc, err := d.Describe()
 				if err != nil {
@@ -115,9 +127,9 @@ func registerResources(srv *server.Server, root string) {
 				MimeType:    "application/json",
 			},
 			Handler: func(ctx context.Context, uri string, params map[string]string) (mcpcore.ResourceResult, error) {
-				d, err := openDeck(root, params["name"])
+				d, err := openDeckForResource(ctx, params["name"])
 				if err != nil {
-					return mcpcore.ResourceResult{}, fmt.Errorf("deck %q not found: %w", params["name"], err)
+					return mcpcore.ResourceResult{}, err
 				}
 				desc, err := d.Describe()
 				if err != nil {
@@ -143,9 +155,9 @@ func registerResources(srv *server.Server, root string) {
 				MimeType:    "text/html",
 			},
 			Handler: func(ctx context.Context, uri string, params map[string]string) (mcpcore.ResourceResult, error) {
-				d, err := openDeck(root, params["name"])
+				d, err := openDeckForResource(ctx, params["name"])
 				if err != nil {
-					return mcpcore.ResourceResult{}, fmt.Errorf("deck %q not found: %w", params["name"], err)
+					return mcpcore.ResourceResult{}, err
 				}
 				n, err := strconv.Atoi(params["n"])
 				if err != nil {
@@ -174,9 +186,9 @@ func registerResources(srv *server.Server, root string) {
 				MimeType:    "text/yaml",
 			},
 			Handler: func(ctx context.Context, uri string, params map[string]string) (mcpcore.ResourceResult, error) {
-				d, err := openDeck(root, params["name"])
+				d, err := openDeckForResource(ctx, params["name"])
 				if err != nil {
-					return mcpcore.ResourceResult{}, fmt.Errorf("deck %q not found: %w", params["name"], err)
+					return mcpcore.ResourceResult{}, err
 				}
 				data, err := d.FS.ReadFile(".slyds.yaml")
 				if err != nil {
@@ -201,9 +213,9 @@ func registerResources(srv *server.Server, root string) {
 				MimeType:    "text/markdown",
 			},
 			Handler: func(ctx context.Context, uri string, params map[string]string) (mcpcore.ResourceResult, error) {
-				d, err := openDeck(root, params["name"])
+				d, err := openDeckForResource(ctx, params["name"])
 				if err != nil {
-					return mcpcore.ResourceResult{}, fmt.Errorf("deck %q not found: %w", params["name"], err)
+					return mcpcore.ResourceResult{}, err
 				}
 				data, err := d.FS.ReadFile("AGENT.md")
 				if err != nil {
@@ -219,4 +231,19 @@ func registerResources(srv *server.Server, root string) {
 			},
 		},
 	)
+}
+
+// openDeckForResource is the resource-handler twin of openDeckFromContext.
+// It returns a plain error (not a ToolResult) so resource handlers can use
+// their standard (ResourceResult, error) return signature.
+func openDeckForResource(ctx context.Context, name string) (*core.Deck, error) {
+	ws := workspaceFromContext(ctx)
+	if ws == nil {
+		return nil, fmt.Errorf("internal: no workspace on context")
+	}
+	d, err := ws.OpenDeck(name)
+	if err != nil {
+		return nil, fmt.Errorf("deck %q not found: %w", name, err)
+	}
+	return d, nil
 }

--- a/cmd/mcp_resources_test.go
+++ b/cmd/mcp_resources_test.go
@@ -11,76 +11,36 @@ import (
 	"github.com/panyam/slyds/core"
 )
 
-// TestDiscoverDecks verifies that discoverDecks finds all subdirectories
-// containing index.html under the given root.
-func TestDiscoverDecks(t *testing.T) {
-	root := t.TempDir()
-	core.CreateInDir("Alpha", 2, "default", filepath.Join(root, "alpha"), true)
-	core.CreateInDir("Beta", 3, "dark", filepath.Join(root, "beta"), true)
+// NOTE: TestDiscoverDecks, TestDiscoverDecksEmpty, TestDiscoverDecksRootIsDeck,
+// and TestOpenDeck previously exercised package-private helpers (`discoverDecks`,
+// `openDeck`) that the Workspace refactor removed. Equivalent coverage now lives
+// in cmd/workspace_test.go against LocalWorkspace.ListDecks and .OpenDeck with
+// stricter assertions (matches by name instead of count only).
 
-	decks := discoverDecks(root)
-	if len(decks) != 2 {
-		t.Errorf("expected 2 decks, got %d: %v", len(decks), decks)
-	}
-}
-
-// TestDiscoverDecksEmpty verifies that an empty directory yields no decks.
-func TestDiscoverDecksEmpty(t *testing.T) {
-	decks := discoverDecks(t.TempDir())
-	if len(decks) != 0 {
-		t.Errorf("expected 0 decks, got %d", len(decks))
-	}
-}
-
-// TestDiscoverDecksRootIsDeck verifies that when the root directory itself
-// contains index.html, it is discovered as deck ".".
-func TestDiscoverDecksRootIsDeck(t *testing.T) {
-	root := t.TempDir()
-	core.CreateInDir("Root Deck", 2, "default", root, true)
-
-	decks := discoverDecks(root)
-	found := false
-	for _, d := range decks {
-		if d == "." {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("root deck not discovered as '.': %v", decks)
-	}
-}
-
-// TestOpenDeck verifies that openDeck resolves a deck name to a Deck
-// instance with the correct title and slide count.
-func TestOpenDeck(t *testing.T) {
-	root := t.TempDir()
-	core.CreateInDir("Test", 3, "default", filepath.Join(root, "my-deck"), true)
-
-	d, err := openDeck(root, "my-deck")
-	if err != nil {
-		t.Fatalf("openDeck: %v", err)
-	}
-	if d.Title() != "Test" {
-		t.Errorf("title = %q, want Test", d.Title())
-	}
-	count, _ := d.SlideCount()
-	if count != 3 {
-		t.Errorf("slides = %d, want 3", count)
-	}
-}
-
-// TestResourceRegistration verifies that registerResources succeeds and
-// the registered deck is readable through the Deck API.
+// TestResourceRegistration verifies that registerResources succeeds with
+// the workspace middleware installed and the registered deck is readable
+// through the Workspace API. The middleware path is the production wiring,
+// so this test doubles as a smoke check for the wiring.
 func TestResourceRegistration(t *testing.T) {
 	root := t.TempDir()
 	core.CreateInDir("Deck", 2, "default", filepath.Join(root, "test-deck"), true)
 
-	srv := server.NewServer(mcpcore.ServerInfo{Name: "test", Version: "0.0.1"})
-	registerResources(srv, root)
-
-	d, err := openDeck(root, "test-deck")
+	ws, err := NewLocalWorkspace(root)
 	if err != nil {
-		t.Fatalf("openDeck: %v", err)
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+
+	srv := server.NewServer(
+		mcpcore.ServerInfo{Name: "test", Version: "0.0.1"},
+		server.WithMiddleware(workspaceMiddleware(ws)),
+	)
+	registerResources(srv)
+
+	// Sanity check: resolve the deck via the workspace directly (what the
+	// resource handlers do when the middleware is active).
+	d, err := ws.OpenDeck("test-deck")
+	if err != nil {
+		t.Fatalf("ws.OpenDeck: %v", err)
 	}
 	content, err := d.GetSlideContent(1)
 	if err != nil {

--- a/cmd/mcp_tools.go
+++ b/cmd/mcp_tools.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	mcpcore "github.com/panyam/mcpkit/core"
@@ -13,20 +12,23 @@ import (
 )
 
 // registerTools registers all semantic MCP tools on the server using
-// single-struct registration (mcpkit v0.1.15).
-func registerTools(srv *server.Server, root string) {
+// single-struct registration (mcpkit v0.1.15). Tool handlers resolve the
+// active Workspace from request context — never from a captured path —
+// so the same factory works for localhost (single static workspace) and
+// for future hosted multi-tenant deployments (per-request workspace).
+func registerTools(srv *server.Server) {
 	srv.Register(
-		listDecksTool(root),
-		createDeckTool(root),
-		describeDeckTool(root),
-		listSlidesTool(root),
-		readSlideTool(root),
-		editSlideTool(root),
-		querySlideTool(root),
-		addSlideTool(root),
-		removeSlideTool(root),
-		checkDeckTool(root),
-		buildDeckTool(root),
+		listDecksTool(),
+		createDeckTool(),
+		describeDeckTool(),
+		listSlidesTool(),
+		readSlideTool(),
+		editSlideTool(),
+		querySlideTool(),
+		addSlideTool(),
+		removeSlideTool(),
+		checkDeckTool(),
+		buildDeckTool(),
 	)
 }
 
@@ -49,27 +51,34 @@ type buildWarningResult struct {
 
 // --- Tool definitions and handlers ---
 
-func listDecksTool(root string) server.Tool {
+func listDecksTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "list_decks",
-			Description: "List all presentation decks under the deck root with name, title, theme, and slide count.",
+			Description: "List all presentation decks visible to the current workspace with name, title, theme, and slide count.",
 			InputSchema: map[string]any{
 				"type":       "object",
 				"properties": map[string]any{},
 			},
 		},
 		Handler: func(ctx context.Context, req mcpcore.ToolRequest) (mcpcore.ToolResult, error) {
-			names := discoverDecks(root)
+			ws, errResult := requireWorkspace(ctx)
+			if errResult != nil {
+				return *errResult, nil
+			}
+			refs, err := ws.ListDecks()
+			if err != nil {
+				return mcpcore.ErrorResult(err.Error()), nil
+			}
 			var decks []deckSummary
-			for _, name := range names {
-				d, err := openDeck(root, name)
+			for _, ref := range refs {
+				d, err := ws.OpenDeck(ref.Name)
 				if err != nil {
 					continue
 				}
 				count, _ := d.SlideCount()
 				decks = append(decks, deckSummary{
-					Name:   name,
+					Name:   ref.Name,
 					Title:  d.Title(),
 					Theme:  d.Theme(),
 					Slides: count,
@@ -80,7 +89,7 @@ func listDecksTool(root string) server.Tool {
 	}
 }
 
-func createDeckTool(root string) server.Tool {
+func createDeckTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "create_deck",
@@ -88,7 +97,7 @@ func createDeckTool(root string) server.Tool {
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"name":   propString("Deck name (becomes the directory name under deck root)"),
+					"name":   propString("Deck name (becomes the deck identifier in the workspace)"),
 					"title":  propString("Presentation title"),
 					"theme":  propString("Theme: default, dark, minimal, corporate, hacker"),
 					"slides": propInt("Number of slides to scaffold (default: 3)"),
@@ -97,6 +106,10 @@ func createDeckTool(root string) server.Tool {
 			},
 		},
 		Handler: func(ctx context.Context, req mcpcore.ToolRequest) (mcpcore.ToolResult, error) {
+			ws, errResult := requireWorkspace(ctx)
+			if errResult != nil {
+				return *errResult, nil
+			}
 			var p struct {
 				Name   string `json:"name"`
 				Title  string `json:"title"`
@@ -112,17 +125,11 @@ func createDeckTool(root string) server.Tool {
 			if p.Slides < 1 {
 				p.Slides = 3
 			}
-			outDir := filepath.Join(root, p.Name)
-			_, err := core.CreateInDir(p.Title, p.Slides, p.Theme, outDir, true)
+			d, err := ws.CreateDeck(p.Name, p.Title, p.Theme, p.Slides)
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
 			mcpcore.NotifyResourcesChanged(ctx)
-			// Return the new deck's metadata
-			d, err := openDeck(root, p.Name)
-			if err != nil {
-				return mcpcore.TextResult(fmt.Sprintf("Deck %q created.", p.Name)), nil
-			}
 			desc, err := d.Describe()
 			if err != nil {
 				return mcpcore.TextResult(fmt.Sprintf("Deck %q created.", p.Name)), nil
@@ -132,7 +139,7 @@ func createDeckTool(root string) server.Tool {
 	}
 }
 
-func describeDeckTool(root string) server.Tool {
+func describeDeckTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "describe_deck",
@@ -144,9 +151,9 @@ func describeDeckTool(root string) server.Tool {
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			desc, err := d.Describe()
 			if err != nil {
@@ -157,7 +164,7 @@ func describeDeckTool(root string) server.Tool {
 	}
 }
 
-func listSlidesTool(root string) server.Tool {
+func listSlidesTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "list_slides",
@@ -169,9 +176,9 @@ func listSlidesTool(root string) server.Tool {
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			desc, err := d.Describe()
 			if err != nil {
@@ -182,7 +189,7 @@ func listSlidesTool(root string) server.Tool {
 	}
 }
 
-func readSlideTool(root string) server.Tool {
+func readSlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "read_slide",
@@ -190,7 +197,7 @@ func readSlideTool(root string) server.Tool {
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"deck":     propString("Deck name (subdirectory under deck root)"),
+					"deck":     propString("Deck name (workspace-scoped identifier)"),
 					"position": propInt("Slide position (1-based)"),
 				},
 				"required": []string{"deck", "position"},
@@ -204,9 +211,9 @@ func readSlideTool(root string) server.Tool {
 			if err := req.Bind(&p); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			content, err := d.GetSlideContent(p.Position)
 			if err != nil {
@@ -217,7 +224,7 @@ func readSlideTool(root string) server.Tool {
 	}
 }
 
-func editSlideTool(root string) server.Tool {
+func editSlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "edit_slide",
@@ -241,9 +248,9 @@ func editSlideTool(root string) server.Tool {
 			if err := req.Bind(&p); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			if err := d.EditSlideContent(p.Position, p.Content); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
@@ -254,7 +261,7 @@ func editSlideTool(root string) server.Tool {
 	}
 }
 
-func querySlideTool(root string) server.Tool {
+func querySlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "query_slide",
@@ -296,9 +303,9 @@ func querySlideTool(root string) server.Tool {
 			if err := req.Bind(&p); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			opts := core.QueryOpts{
 				HTML:    p.HTML,
@@ -320,7 +327,7 @@ func querySlideTool(root string) server.Tool {
 	}
 }
 
-func addSlideTool(root string) server.Tool {
+func addSlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "add_slide",
@@ -351,9 +358,9 @@ func addSlideTool(root string) server.Tool {
 			if p.Layout == "" {
 				p.Layout = "content"
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			if err := d.InsertSlide(p.Position, p.Name, p.Layout, p.Title); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
@@ -364,7 +371,7 @@ func addSlideTool(root string) server.Tool {
 	}
 }
 
-func removeSlideTool(root string) server.Tool {
+func removeSlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "remove_slide",
@@ -386,9 +393,9 @@ func removeSlideTool(root string) server.Tool {
 			if err := req.Bind(&p); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			// Resolve slide reference to filename
 			filename, err := d.ResolveSlide(p.Slide)
@@ -404,7 +411,7 @@ func removeSlideTool(root string) server.Tool {
 	}
 }
 
-func checkDeckTool(root string) server.Tool {
+func checkDeckTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "check_deck",
@@ -417,9 +424,9 @@ func checkDeckTool(root string) server.Tool {
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			issues, err := d.Check()
 			if err != nil {
@@ -430,7 +437,7 @@ func checkDeckTool(root string) server.Tool {
 	}
 }
 
-func buildDeckTool(root string) server.Tool {
+func buildDeckTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "build_deck",
@@ -443,9 +450,9 @@ func buildDeckTool(root string) server.Tool {
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
-			d, err := openDeck(root, p.Deck)
-			if err != nil {
-				return mcpcore.ErrorResult(err.Error()), nil
+			d, errResult := openDeckFromContext(ctx, p.Deck)
+			if errResult != nil {
+				return *errResult, nil
 			}
 			result, err := d.Build()
 			if err != nil {
@@ -470,7 +477,7 @@ func deckOnlySchema() map[string]any {
 	return map[string]any{
 		"type": "object",
 		"properties": map[string]any{
-			"deck": propString("Deck name (subdirectory under deck root, or '.' for root deck)"),
+			"deck": propString("Deck name (workspace-scoped identifier, or '.' for a deck at the workspace root)"),
 		},
 		"required": []string{"deck"},
 	}

--- a/cmd/mcp_tools_test.go
+++ b/cmd/mcp_tools_test.go
@@ -24,12 +24,25 @@ func scaffoldTestDeck(t *testing.T, name, title, theme string, slides int) strin
 	return root
 }
 
+// workspaceCtx returns a context with a LocalWorkspace rooted at the given
+// path pre-installed. Used by unit tests that invoke tool handlers directly
+// without going through the full middleware chain.
+func workspaceCtx(t *testing.T, root string) context.Context {
+	t.Helper()
+	ws, err := NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+	return withWorkspace(context.Background(), ws)
+}
+
 // callTool invokes a tool handler directly with JSON-marshalled arguments
-// and returns the ToolResult. Fails the test on handler errors.
-func callTool(t *testing.T, handler mcpcore.ToolHandler, args any) mcpcore.ToolResult {
+// and a context carrying a LocalWorkspace rooted at the given path. Fails
+// the test on handler errors.
+func callTool(t *testing.T, root string, handler mcpcore.ToolHandler, args any) mcpcore.ToolResult {
 	t.Helper()
 	data, _ := json.Marshal(args)
-	result, err := handler(context.Background(), mcpcore.ToolRequest{
+	result, err := handler(workspaceCtx(t, root), mcpcore.ToolRequest{
 		Arguments: data,
 	})
 	if err != nil {
@@ -50,9 +63,9 @@ func toolText(result mcpcore.ToolResult) string {
 // with the deck title, slide count, and slide metadata.
 func TestDescribeDeckTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Test Deck", "default", 3)
-	tool := describeDeckTool(root)
+	tool := describeDeckTool()
 
-	result := callTool(t, tool.Handler, map[string]string{"deck": "test-deck"})
+	result := callTool(t, root, tool.Handler, map[string]string{"deck": "test-deck"})
 	if result.IsError {
 		t.Fatalf("describe_deck error: %s", toolText(result))
 	}
@@ -70,9 +83,9 @@ func TestDescribeDeckTool(t *testing.T) {
 // the correct number of slides and their metadata.
 func TestListSlidesTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Test", "default", 4)
-	tool := listSlidesTool(root)
+	tool := listSlidesTool()
 
-	result := callTool(t, tool.Handler, map[string]string{"deck": "test-deck"})
+	result := callTool(t, root, tool.Handler, map[string]string{"deck": "test-deck"})
 	if result.IsError {
 		t.Fatalf("list_slides error: %s", toolText(result))
 	}
@@ -88,9 +101,9 @@ func TestListSlidesTool(t *testing.T) {
 // of a slide at a given position, including the slide class and title.
 func TestReadSlideTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Read Test", "default", 3)
-	tool := readSlideTool(root)
+	tool := readSlideTool()
 
-	result := callTool(t, tool.Handler, map[string]any{"deck": "test-deck", "position": 1})
+	result := callTool(t, root, tool.Handler, map[string]any{"deck": "test-deck", "position": 1})
 	if result.IsError {
 		t.Fatalf("read_slide error: %s", toolText(result))
 	}
@@ -108,18 +121,18 @@ func TestReadSlideTool(t *testing.T) {
 // and that the change persists when read back via read_slide.
 func TestEditSlideTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Edit Test", "default", 3)
-	editTool := editSlideTool(root)
-	readTool := readSlideTool(root)
+	editTool := editSlideTool()
+	readTool := readSlideTool()
 
 	newContent := `<div class="slide" data-layout="content"><h1>Updated</h1></div>`
-	result := callTool(t, editTool.Handler, map[string]any{
+	result := callTool(t, root, editTool.Handler, map[string]any{
 		"deck": "test-deck", "position": 2, "content": newContent,
 	})
 	if result.IsError {
 		t.Fatalf("edit_slide error: %s", toolText(result))
 	}
 
-	result = callTool(t, readTool.Handler, map[string]any{"deck": "test-deck", "position": 2})
+	result = callTool(t, root, readTool.Handler, map[string]any{"deck": "test-deck", "position": 2})
 	if !strings.Contains(toolText(result), "Updated") {
 		t.Error("edit_slide content not persisted")
 	}
@@ -129,9 +142,9 @@ func TestEditSlideTool(t *testing.T) {
 // content from slides — here, reading the h1 text from the title slide.
 func TestQuerySlideTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Query Test", "default", 3)
-	tool := querySlideTool(root)
+	tool := querySlideTool()
 
-	result := callTool(t, tool.Handler, map[string]any{
+	result := callTool(t, root, tool.Handler, map[string]any{
 		"deck": "test-deck", "slide": "1", "selector": "h1",
 	})
 	if result.IsError {
@@ -149,30 +162,30 @@ func TestQuerySlideTool(t *testing.T) {
 // confirms the count returned to the original.
 func TestAddAndRemoveSlideTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "CRUD Test", "default", 3)
-	addTool := addSlideTool(root)
-	removeTool := removeSlideTool(root)
-	listTool := listSlidesTool(root)
+	addTool := addSlideTool()
+	removeTool := removeSlideTool()
+	listTool := listSlidesTool()
 
-	result := callTool(t, addTool.Handler, map[string]any{
+	result := callTool(t, root, addTool.Handler, map[string]any{
 		"deck": "test-deck", "position": 2, "name": "new-slide", "layout": "content", "title": "New",
 	})
 	if result.IsError {
 		t.Fatalf("add_slide error: %s", toolText(result))
 	}
 
-	result = callTool(t, listTool.Handler, map[string]string{"deck": "test-deck"})
+	result = callTool(t, root, listTool.Handler, map[string]string{"deck": "test-deck"})
 	var slides []map[string]any
 	json.Unmarshal([]byte(toolText(result)), &slides)
 	if len(slides) != 4 {
 		t.Errorf("after add: expected 4 slides, got %d", len(slides))
 	}
 
-	result = callTool(t, removeTool.Handler, map[string]any{"deck": "test-deck", "slide": "2"})
+	result = callTool(t, root, removeTool.Handler, map[string]any{"deck": "test-deck", "slide": "2"})
 	if result.IsError {
 		t.Fatalf("remove_slide error: %s", toolText(result))
 	}
 
-	result = callTool(t, listTool.Handler, map[string]string{"deck": "test-deck"})
+	result = callTool(t, root, listTool.Handler, map[string]string{"deck": "test-deck"})
 	json.Unmarshal([]byte(toolText(result)), &slides)
 	if len(slides) != 3 {
 		t.Errorf("after remove: expected 3 slides, got %d", len(slides))
@@ -183,9 +196,9 @@ func TestAddAndRemoveSlideTool(t *testing.T) {
 // InSync field indicating deck validation status.
 func TestCheckDeckTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Check Test", "default", 3)
-	tool := checkDeckTool(root)
+	tool := checkDeckTool()
 
-	result := callTool(t, tool.Handler, map[string]string{"deck": "test-deck"})
+	result := callTool(t, root, tool.Handler, map[string]string{"deck": "test-deck"})
 	if result.IsError {
 		t.Fatalf("check_deck error: %s", toolText(result))
 	}
@@ -199,9 +212,9 @@ func TestCheckDeckTool(t *testing.T) {
 // file with inlined CSS and the presentation title.
 func TestBuildDeckTool(t *testing.T) {
 	root := scaffoldTestDeck(t, "test-deck", "Build Test", "default", 3)
-	tool := buildDeckTool(root)
+	tool := buildDeckTool()
 
-	result := callTool(t, tool.Handler, map[string]string{"deck": "test-deck"})
+	result := callTool(t, root, tool.Handler, map[string]string{"deck": "test-deck"})
 	if result.IsError {
 		t.Fatalf("build_deck error: %s", toolText(result))
 	}
@@ -216,12 +229,12 @@ func TestBuildDeckTool(t *testing.T) {
 }
 
 // TestCreateDeckTool verifies that create_deck scaffolds a new deck in the
-// deck root, returns its metadata, and the deck is readable via OpenDeckDir.
+// workspace, returns its metadata, and the deck is readable via the Deck API.
 func TestCreateDeckTool(t *testing.T) {
 	root := t.TempDir()
-	tool := createDeckTool(root)
+	tool := createDeckTool()
 
-	result := callTool(t, tool.Handler, map[string]any{
+	result := callTool(t, root, tool.Handler, map[string]any{
 		"name": "new-deck", "title": "Created Deck", "theme": "dark", "slides": 2,
 	})
 	if result.IsError {
@@ -250,10 +263,47 @@ func TestCreateDeckTool(t *testing.T) {
 // specified deck directory doesn't exist.
 func TestToolDeckNotFound(t *testing.T) {
 	root := t.TempDir()
-	tool := describeDeckTool(root)
+	tool := describeDeckTool()
 
-	result := callTool(t, tool.Handler, map[string]string{"deck": "nonexistent"})
+	result := callTool(t, root, tool.Handler, map[string]string{"deck": "nonexistent"})
 	if !result.IsError {
 		t.Error("expected error for nonexistent deck")
+	}
+}
+
+// TestMCPTools_NoWorkspaceReturnsError verifies that every tool handler
+// returns a clean error (instead of panicking) when invoked with a context
+// that has no workspace installed. This prevents silent nil-pointer bugs
+// if the middleware is accidentally removed from the server wiring.
+func TestMCPTools_NoWorkspaceReturnsError(t *testing.T) {
+	tools := map[string]mcpcore.ToolHandler{
+		"list_decks":    listDecksTool().Handler,
+		"describe_deck": describeDeckTool().Handler,
+		"list_slides":   listSlidesTool().Handler,
+		"read_slide":    readSlideTool().Handler,
+		"edit_slide":    editSlideTool().Handler,
+		"query_slide":   querySlideTool().Handler,
+		"add_slide":     addSlideTool().Handler,
+		"remove_slide":  removeSlideTool().Handler,
+		"check_deck":    checkDeckTool().Handler,
+		"build_deck":    buildDeckTool().Handler,
+		"create_deck":   createDeckTool().Handler,
+	}
+	for name, handler := range tools {
+		t.Run(name, func(t *testing.T) {
+			// Bare context, no workspace installed.
+			result, err := handler(context.Background(), mcpcore.ToolRequest{
+				Arguments: json.RawMessage(`{"deck":"whatever"}`),
+			})
+			if err != nil {
+				t.Fatalf("handler returned err: %v", err)
+			}
+			if !result.IsError {
+				t.Errorf("expected IsError=true without workspace")
+			}
+			if !strings.Contains(toolText(result), "workspace") {
+				t.Errorf("error should mention workspace; got: %s", toolText(result))
+			}
+		})
 	}
 }

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	mcpcore "github.com/panyam/mcpkit/core"
+	"github.com/panyam/mcpkit/server"
+	"github.com/panyam/slyds/core"
+)
+
+// Workspace is a handle to a set of decks plus the policies for opening,
+// listing, and creating them. MCP tool and resource handlers resolve decks
+// via a Workspace — never through raw filesystem paths.
+//
+// Today there is one implementation (LocalWorkspace). HostedWorkspace and
+// MultiRootWorkspace are planned (see issue #74 and #76). The interface
+// intentionally exposes the minimum surface needed by the current MCP
+// handlers; new methods are added only when the feature that needs them
+// lands.
+type Workspace interface {
+	// OpenDeck resolves a deck name to a *core.Deck. Returns an error if
+	// the deck doesn't exist, the name is invalid, or the caller is not
+	// authorized to see it. Missing and unauthorized are both surfaced as
+	// ErrDeckNotFound so future backends don't leak existence across
+	// tenants.
+	OpenDeck(name string) (*core.Deck, error)
+
+	// ListDecks returns the decks visible to this workspace.
+	ListDecks() ([]DeckRef, error)
+
+	// CreateDeck scaffolds a new deck under the workspace and returns the
+	// opened Deck. The name becomes the deck's directory (or canonical
+	// identifier in future backends). Returns ErrInvalidDeckName if the
+	// name contains disallowed characters.
+	CreateDeck(name, title, theme string, slides int) (*core.Deck, error)
+}
+
+// DeckRef identifies a deck within a workspace. Kept small for now; future
+// fields (canonical URI, root name, shared-from identity) are added when
+// the features that need them ship.
+type DeckRef struct {
+	// Name is the workspace-local identifier for the deck. For
+	// LocalWorkspace this is the subdirectory name, or "." for a deck
+	// located at the workspace root itself.
+	Name string
+}
+
+// ErrDeckNotFound is returned by Workspace.OpenDeck when the deck does not
+// exist or the caller cannot see it. Callers should use errors.Is to check
+// for this error rather than string matching.
+var ErrDeckNotFound = errors.New("deck not found")
+
+// ErrInvalidDeckName is returned when a deck name contains a path separator
+// or other disallowed character. Enforced early so future multi-root
+// implementations can reliably use "/" as a root/deck separator without
+// ambiguity.
+var ErrInvalidDeckName = errors.New("invalid deck name")
+
+// validateDeckName rejects names that would escape the workspace, collide
+// with the multi-root separator, or otherwise confuse the resolver. The "."
+// sentinel (meaning "the deck at the workspace root") is allowed.
+func validateDeckName(name string) error {
+	if name == "." || name == "" {
+		return nil
+	}
+	if strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return fmt.Errorf("%w: %q contains a path separator", ErrInvalidDeckName, name)
+	}
+	if strings.HasPrefix(name, "..") || strings.HasPrefix(name, ".") {
+		return fmt.Errorf("%w: %q begins with a dot", ErrInvalidDeckName, name)
+	}
+	return nil
+}
+
+// LocalWorkspace is a single-root workspace backed by the local filesystem
+// via templar.LocalFS (indirectly through core.OpenDeckDir). All decks live
+// as subdirectories under the workspace root; an index.html at the root
+// itself is exposed as the "." deck.
+type LocalWorkspace struct {
+	root string
+}
+
+// NewLocalWorkspace constructs a LocalWorkspace rooted at the given path.
+// The path is resolved to an absolute path immediately; relative paths are
+// resolved against the current working directory at construction time.
+func NewLocalWorkspace(root string) (*LocalWorkspace, error) {
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("invalid workspace root %q: %w", root, err)
+	}
+	return &LocalWorkspace{root: abs}, nil
+}
+
+// Root returns the absolute root path of this workspace. Used by the MCP
+// landing page and stdio config printer to display the deck discovery root
+// to humans; tool and resource handlers should not call this.
+func (w *LocalWorkspace) Root() string { return w.root }
+
+// OpenDeck resolves a deck name to a *core.Deck via core.OpenDeckDir.
+// Errors from the underlying filesystem are mapped to ErrDeckNotFound so
+// callers can treat "missing" and "unauthorized" uniformly.
+func (w *LocalWorkspace) OpenDeck(name string) (*core.Deck, error) {
+	if err := validateDeckName(name); err != nil {
+		return nil, err
+	}
+	var dir string
+	if name == "." || name == "" {
+		dir = w.root
+	} else {
+		dir = filepath.Join(w.root, name)
+	}
+	d, err := core.OpenDeckDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrDeckNotFound, name)
+	}
+	return d, nil
+}
+
+// ListDecks returns a DeckRef for each subdirectory of the workspace root
+// that contains an index.html, plus a "." entry if the root itself is a
+// deck. The scan is shallow — nested deck directories are not discovered.
+func (w *LocalWorkspace) ListDecks() ([]DeckRef, error) {
+	var refs []DeckRef
+	if _, err := os.Stat(filepath.Join(w.root, "index.html")); err == nil {
+		refs = append(refs, DeckRef{Name: "."})
+	}
+	entries, err := os.ReadDir(w.root)
+	if err != nil {
+		// ReadDir failing is not fatal — return what we have. An empty
+		// workspace directory returns zero refs.
+		return refs, nil
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(w.root, e.Name(), "index.html")); err == nil {
+			refs = append(refs, DeckRef{Name: e.Name()})
+		}
+	}
+	return refs, nil
+}
+
+// CreateDeck scaffolds a new deck at {root}/{name} via core.CreateInDir and
+// returns the opened Deck. Rejects names containing path separators so the
+// new directory can never escape the workspace root.
+func (w *LocalWorkspace) CreateDeck(name, title, theme string, slides int) (*core.Deck, error) {
+	if err := validateDeckName(name); err != nil {
+		return nil, err
+	}
+	if name == "." || name == "" {
+		return nil, fmt.Errorf("%w: cannot create deck at workspace root", ErrInvalidDeckName)
+	}
+	outDir := filepath.Join(w.root, name)
+	if _, err := core.CreateInDir(title, slides, theme, outDir, true); err != nil {
+		return nil, err
+	}
+	return w.OpenDeck(name)
+}
+
+// --- Workspace context plumbing ---
+
+// workspaceKeyType is an unexported type used as the context key for the
+// active Workspace. Using an unexported type prevents collisions with keys
+// set by other packages.
+type workspaceKeyType struct{}
+
+// workspaceKey is the context key under which the request-scoped Workspace
+// is stored. Installed by workspaceMiddleware and read by handlers via
+// workspaceFromContext.
+var workspaceKey = workspaceKeyType{}
+
+// workspaceFromContext returns the Workspace previously installed on ctx
+// by workspaceMiddleware. Returns nil if no workspace has been installed
+// (which should never happen in a properly configured server — handlers
+// should treat nil as an internal error and return it via ErrorResult).
+func workspaceFromContext(ctx context.Context) Workspace {
+	ws, _ := ctx.Value(workspaceKey).(Workspace)
+	return ws
+}
+
+// withWorkspace returns a new context with the given Workspace installed.
+// Exposed for tests that need to invoke a tool handler directly without
+// going through the middleware chain.
+func withWorkspace(ctx context.Context, ws Workspace) context.Context {
+	return context.WithValue(ctx, workspaceKey, ws)
+}
+
+// workspaceMiddleware returns an mcpkit Middleware that installs the given
+// Workspace on every request context before the handler runs. For localhost
+// the workspace is a single LocalWorkspace constructed at server startup;
+// a future HostedWorkspace variant would resolve a per-request workspace
+// from authentication instead of capturing a constant.
+func workspaceMiddleware(ws Workspace) server.Middleware {
+	return func(ctx context.Context, req *mcpcore.Request, next server.MiddlewareFunc) *mcpcore.Response {
+		ctx = withWorkspace(ctx, ws)
+		return next(ctx, req)
+	}
+}
+
+// requireWorkspace is a small helper for tool handlers: fetches the
+// Workspace from context and returns a structured error result if it is
+// missing. Centralizes the nil check so every handler doesn't repeat it.
+func requireWorkspace(ctx context.Context) (Workspace, *mcpcore.ToolResult) {
+	ws := workspaceFromContext(ctx)
+	if ws == nil {
+		r := mcpcore.ErrorResult("internal: no workspace on context")
+		return nil, &r
+	}
+	return ws, nil
+}
+
+// openDeckFromContext resolves the workspace from ctx and opens the named
+// deck in one call. Used by tool handlers that need a Deck immediately —
+// collapses the "require workspace + open deck" idiom into a single line.
+// Returns a non-nil *mcpcore.ToolResult (to be returned from the handler)
+// when the workspace is missing or the deck cannot be opened.
+func openDeckFromContext(ctx context.Context, name string) (*core.Deck, *mcpcore.ToolResult) {
+	ws, errResult := requireWorkspace(ctx)
+	if errResult != nil {
+		return nil, errResult
+	}
+	d, err := ws.OpenDeck(name)
+	if err != nil {
+		r := mcpcore.ErrorResult(err.Error())
+		return nil, &r
+	}
+	return d, nil
+}

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -238,3 +238,25 @@ func TestWorkspaceFromContext_MissingReturnsNil(t *testing.T) {
 		t.Errorf("workspaceFromContext(bare ctx) = %v, want nil", ws)
 	}
 }
+
+// TestResolveDeckRoot_Precedence verifies the fallback chain:
+// explicit flag value > SLYDS_DECK_ROOT env var > "." default. Shared by
+// `slyds mcp` and `slyds ws` so their deck-root resolution is identical.
+func TestResolveDeckRoot_Precedence(t *testing.T) {
+	// Flag wins even when env is set.
+	t.Setenv("SLYDS_DECK_ROOT", "/env/path")
+	if got := resolveDeckRoot("/flag/path"); got != "/flag/path" {
+		t.Errorf("resolveDeckRoot(flag) = %q, want /flag/path", got)
+	}
+
+	// Env used when flag is empty.
+	if got := resolveDeckRoot(""); got != "/env/path" {
+		t.Errorf("resolveDeckRoot(empty) with env = %q, want /env/path", got)
+	}
+
+	// Default "." when both flag and env are empty.
+	t.Setenv("SLYDS_DECK_ROOT", "")
+	if got := resolveDeckRoot(""); got != "." {
+		t.Errorf("resolveDeckRoot(empty) without env = %q, want .", got)
+	}
+}

--- a/cmd/workspace_test.go
+++ b/cmd/workspace_test.go
@@ -1,0 +1,240 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	mcpcore "github.com/panyam/mcpkit/core"
+	"github.com/panyam/slyds/core"
+)
+
+// TestLocalWorkspace_OpenDeck_Basic verifies that a LocalWorkspace can open
+// a deck that exists as a subdirectory under the workspace root. This is
+// the happy-path replacement for the old TestOpenDeck which exercised the
+// package-private openDeck(root, name) helper.
+func TestLocalWorkspace_OpenDeck_Basic(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Alpha Talk", 3, "default", filepath.Join(root, "alpha"), true)
+
+	ws, err := NewLocalWorkspace(root)
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace: %v", err)
+	}
+
+	d, err := ws.OpenDeck("alpha")
+	if err != nil {
+		t.Fatalf("OpenDeck: %v", err)
+	}
+	if d.Title() != "Alpha Talk" {
+		t.Errorf("Title = %q, want %q", d.Title(), "Alpha Talk")
+	}
+	count, _ := d.SlideCount()
+	if count != 3 {
+		t.Errorf("SlideCount = %d, want 3", count)
+	}
+}
+
+// TestLocalWorkspace_OpenDeck_InvalidName verifies that deck names containing
+// path separators or leading dots are rejected with ErrInvalidDeckName before
+// any filesystem access happens. This protects against path escape bugs and
+// reserves "/" for future multi-root workspace name qualification.
+func TestLocalWorkspace_OpenDeck_InvalidName(t *testing.T) {
+	root := t.TempDir()
+	ws, _ := NewLocalWorkspace(root)
+
+	cases := []string{
+		"../escape",
+		"root/sub",
+		"..secret",
+		`root\sub`,
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ws.OpenDeck(name)
+			if !errors.Is(err, ErrInvalidDeckName) {
+				t.Errorf("OpenDeck(%q) error = %v, want ErrInvalidDeckName", name, err)
+			}
+		})
+	}
+}
+
+// TestLocalWorkspace_OpenDeck_NotFound verifies that opening a non-existent
+// deck returns ErrDeckNotFound rather than a low-level filesystem error.
+// Uniform not-found mapping matters for the future HostedWorkspace where
+// leaking "exists but unauthorized" vs "doesn't exist" would be a tenancy
+// information leak.
+func TestLocalWorkspace_OpenDeck_NotFound(t *testing.T) {
+	root := t.TempDir()
+	ws, _ := NewLocalWorkspace(root)
+
+	_, err := ws.OpenDeck("ghost")
+	if !errors.Is(err, ErrDeckNotFound) {
+		t.Errorf("OpenDeck(\"ghost\") error = %v, want ErrDeckNotFound", err)
+	}
+}
+
+// TestLocalWorkspace_OpenDeck_RootDeck verifies that the "." sentinel name
+// opens the deck at the workspace root itself (when one exists). This
+// supports the "my project IS a deck" case where --deck-root points at a
+// deck directory directly.
+func TestLocalWorkspace_OpenDeck_RootDeck(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Root Deck", 2, "default", root, true)
+
+	ws, _ := NewLocalWorkspace(root)
+	d, err := ws.OpenDeck(".")
+	if err != nil {
+		t.Fatalf("OpenDeck(\".\"): %v", err)
+	}
+	if d.Title() != "Root Deck" {
+		t.Errorf("Title = %q, want %q", d.Title(), "Root Deck")
+	}
+}
+
+// TestLocalWorkspace_ListDecks_Empty verifies that an empty workspace
+// directory yields zero refs (and not an error). Regression guard for
+// the old TestDiscoverDecksEmpty.
+func TestLocalWorkspace_ListDecks_Empty(t *testing.T) {
+	ws, _ := NewLocalWorkspace(t.TempDir())
+	refs, err := ws.ListDecks()
+	if err != nil {
+		t.Fatalf("ListDecks: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("ListDecks = %v, want 0 refs", refs)
+	}
+}
+
+// TestLocalWorkspace_ListDecks_Multiple verifies that every subdirectory
+// containing index.html is returned as a DeckRef. Regression guard for
+// the old TestDiscoverDecks.
+func TestLocalWorkspace_ListDecks_Multiple(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Alpha", 2, "default", filepath.Join(root, "alpha"), true)
+	core.CreateInDir("Beta", 3, "dark", filepath.Join(root, "beta"), true)
+	core.CreateInDir("Gamma", 4, "default", filepath.Join(root, "gamma"), true)
+
+	ws, _ := NewLocalWorkspace(root)
+	refs, err := ws.ListDecks()
+	if err != nil {
+		t.Fatalf("ListDecks: %v", err)
+	}
+	if len(refs) != 3 {
+		t.Fatalf("ListDecks: got %d refs, want 3: %v", len(refs), refs)
+	}
+
+	got := map[string]bool{}
+	for _, r := range refs {
+		got[r.Name] = true
+	}
+	for _, want := range []string{"alpha", "beta", "gamma"} {
+		if !got[want] {
+			t.Errorf("ListDecks missing %q; got %v", want, refs)
+		}
+	}
+}
+
+// TestLocalWorkspace_ListDecks_RootIsDeck verifies that when the workspace
+// root itself contains index.html, ListDecks returns a "." entry. Regression
+// guard for the old TestDiscoverDecksRootIsDeck.
+func TestLocalWorkspace_ListDecks_RootIsDeck(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Root Deck", 2, "default", root, true)
+
+	ws, _ := NewLocalWorkspace(root)
+	refs, _ := ws.ListDecks()
+
+	found := false
+	for _, r := range refs {
+		if r.Name == "." {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("root deck not listed as \".\": %v", refs)
+	}
+}
+
+// TestLocalWorkspace_CreateDeck verifies that CreateDeck scaffolds a new
+// deck, returns the opened Deck with correct title/theme/slide count, and
+// that the new deck is subsequently visible to ListDecks.
+func TestLocalWorkspace_CreateDeck(t *testing.T) {
+	root := t.TempDir()
+	ws, _ := NewLocalWorkspace(root)
+
+	d, err := ws.CreateDeck("new", "New Deck", "default", 3)
+	if err != nil {
+		t.Fatalf("CreateDeck: %v", err)
+	}
+	if d.Title() != "New Deck" {
+		t.Errorf("Title = %q, want %q", d.Title(), "New Deck")
+	}
+	if d.Theme() != "default" {
+		t.Errorf("Theme = %q, want \"default\"", d.Theme())
+	}
+	count, _ := d.SlideCount()
+	if count != 3 {
+		t.Errorf("SlideCount = %d, want 3", count)
+	}
+
+	refs, _ := ws.ListDecks()
+	found := false
+	for _, r := range refs {
+		if r.Name == "new" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("created deck not in ListDecks: %v", refs)
+	}
+}
+
+// TestLocalWorkspace_CreateDeck_InvalidName verifies that CreateDeck rejects
+// path-containing names the same way OpenDeck does. This is critical — a
+// name like "../../etc/passwd" must never reach CreateInDir.
+func TestLocalWorkspace_CreateDeck_InvalidName(t *testing.T) {
+	ws, _ := NewLocalWorkspace(t.TempDir())
+
+	_, err := ws.CreateDeck("../escape", "Title", "default", 1)
+	if !errors.Is(err, ErrInvalidDeckName) {
+		t.Errorf("CreateDeck error = %v, want ErrInvalidDeckName", err)
+	}
+}
+
+// TestWorkspaceMiddleware_InjectsIntoContext verifies the wiring contract:
+// when workspaceMiddleware(ws) wraps a handler, the handler sees ws via
+// workspaceFromContext(ctx). This is the primitive every tool handler
+// relies on — if this test fails, every tool in the server is broken.
+func TestWorkspaceMiddleware_InjectsIntoContext(t *testing.T) {
+	want, _ := NewLocalWorkspace(t.TempDir())
+
+	var seen Workspace
+	next := func(ctx context.Context, req *mcpcore.Request) *mcpcore.Response {
+		seen = workspaceFromContext(ctx)
+		return &mcpcore.Response{}
+	}
+
+	mw := workspaceMiddleware(want)
+	mw(context.Background(), &mcpcore.Request{}, next)
+
+	if seen == nil {
+		t.Fatal("workspaceFromContext returned nil inside middleware-wrapped handler")
+	}
+	if seen != want {
+		t.Errorf("workspaceFromContext returned %p, want %p", seen, want)
+	}
+}
+
+// TestWorkspaceFromContext_MissingReturnsNil verifies that reading a
+// workspace from a bare context (no middleware applied) returns nil. This
+// is the contract requireWorkspace relies on to produce a clean error
+// result instead of panicking on a nil-pointer dereference.
+func TestWorkspaceFromContext_MissingReturnsNil(t *testing.T) {
+	if ws := workspaceFromContext(context.Background()); ws != nil {
+		t.Errorf("workspaceFromContext(bare ctx) = %v, want nil", ws)
+	}
+}

--- a/cmd/ws.go
+++ b/cmd/ws.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// wsCmd is a debug/introspection subcommand for the Workspace abstraction.
+// It lets humans see what a `slyds mcp --deck-root DIR` would see without
+// having to start an MCP server and send JSON-RPC. Also used by the demo
+// smoke test (make demo-smoke) to verify the workspace wiring end-to-end.
+var wsCmd = &cobra.Command{
+	Use:   "ws",
+	Short: "Inspect the current workspace (deck root and visible decks)",
+	Long: `ws is a small debug/introspection subcommand for the Workspace layer.
+
+Subcommands:
+  slyds ws info            Print the workspace root path
+  slyds ws list            List decks visible to the workspace
+
+Workspaces are how the MCP server resolves decks from authenticated context.
+For the CLI, there is one implicit workspace rooted at --deck-root (default: ".").`,
+}
+
+var (
+	wsDeckRoot string
+	wsJSON     bool
+)
+
+var wsInfoCmd = &cobra.Command{
+	Use:   "info",
+	Short: "Print the workspace root path and deck count",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ws, err := NewLocalWorkspace(wsDeckRoot)
+		if err != nil {
+			return err
+		}
+		refs, err := ws.ListDecks()
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+		info := map[string]any{
+			"root":       ws.Root(),
+			"deck_count": len(refs),
+			"kind":       "local",
+		}
+		if wsJSON {
+			data, _ := json.MarshalIndent(info, "", "  ")
+			fmt.Fprintln(out, string(data))
+			return nil
+		}
+		fmt.Fprintf(out, "Workspace: local\n")
+		fmt.Fprintf(out, "Root:      %s\n", ws.Root())
+		fmt.Fprintf(out, "Decks:     %d\n", len(refs))
+		return nil
+	},
+}
+
+var wsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List decks visible to the workspace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ws, err := NewLocalWorkspace(wsDeckRoot)
+		if err != nil {
+			return err
+		}
+		refs, err := ws.ListDecks()
+		if err != nil {
+			return err
+		}
+		out := cmd.OutOrStdout()
+
+		if wsJSON {
+			// Return full metadata for each deck — matches the `list_decks`
+			// MCP tool output so scripts that consume one can consume the
+			// other.
+			summaries := make([]deckSummary, 0, len(refs))
+			for _, ref := range refs {
+				d, err := ws.OpenDeck(ref.Name)
+				if err != nil {
+					continue
+				}
+				count, _ := d.SlideCount()
+				summaries = append(summaries, deckSummary{
+					Name:   ref.Name,
+					Title:  d.Title(),
+					Theme:  d.Theme(),
+					Slides: count,
+				})
+			}
+			data, _ := json.MarshalIndent(summaries, "", "  ")
+			fmt.Fprintln(out, string(data))
+			return nil
+		}
+
+		if len(refs) == 0 {
+			fmt.Fprintln(out, "(no decks)")
+			return nil
+		}
+		for _, ref := range refs {
+			d, err := ws.OpenDeck(ref.Name)
+			if err != nil {
+				fmt.Fprintf(out, "%-30s  (error: %v)\n", ref.Name, err)
+				continue
+			}
+			count, _ := d.SlideCount()
+			fmt.Fprintf(out, "%-30s  %-10s  %3d slides  %s\n",
+				ref.Name, d.Theme(), count, d.Title())
+		}
+		return nil
+	},
+}
+
+func init() {
+	wsCmd.PersistentFlags().StringVar(&wsDeckRoot, "deck-root", ".", "Workspace root directory")
+	wsCmd.PersistentFlags().BoolVar(&wsJSON, "json", false, "Output as JSON instead of human-readable text")
+	wsCmd.AddCommand(wsInfoCmd)
+	wsCmd.AddCommand(wsListCmd)
+	rootCmd.AddCommand(wsCmd)
+}

--- a/cmd/ws.go
+++ b/cmd/ws.go
@@ -33,7 +33,7 @@ var wsInfoCmd = &cobra.Command{
 	Use:   "info",
 	Short: "Print the workspace root path and deck count",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ws, err := NewLocalWorkspace(wsDeckRoot)
+		ws, err := NewLocalWorkspace(resolveDeckRoot(wsDeckRoot))
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ var wsListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List decks visible to the workspace",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ws, err := NewLocalWorkspace(wsDeckRoot)
+		ws, err := NewLocalWorkspace(resolveDeckRoot(wsDeckRoot))
 		if err != nil {
 			return err
 		}
@@ -115,7 +115,7 @@ var wsListCmd = &cobra.Command{
 }
 
 func init() {
-	wsCmd.PersistentFlags().StringVar(&wsDeckRoot, "deck-root", ".", "Workspace root directory")
+	wsCmd.PersistentFlags().StringVar(&wsDeckRoot, "deck-root", "", "Workspace root directory (default: $SLYDS_DECK_ROOT, or current directory)")
 	wsCmd.PersistentFlags().BoolVar(&wsJSON, "json", false, "Output as JSON instead of human-readable text")
 	wsCmd.AddCommand(wsInfoCmd)
 	wsCmd.AddCommand(wsListCmd)

--- a/cmd/ws_test.go
+++ b/cmd/ws_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/panyam/slyds/core"
+)
+
+// runWsCmd executes the `ws` subcommand with the given args, capturing
+// stdout. Uses the global `wsCmd` cobra tree with a fresh stdout buffer
+// so each test is isolated.
+func runWsCmd(t *testing.T, args ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	wsCmd.SetOut(&buf)
+	wsCmd.SetErr(&buf)
+	wsCmd.SetArgs(args)
+	if err := wsCmd.Execute(); err != nil {
+		t.Fatalf("ws cmd: %v", err)
+	}
+	return buf.String()
+}
+
+// TestWsInfoHumanReadable verifies that `slyds ws info` prints the workspace
+// root and deck count in human-readable form. This is the smoke-test path
+// that Makefile demo-smoke target invokes.
+func TestWsInfoHumanReadable(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Info Test", 2, "default", filepath.Join(root, "alpha"), true)
+
+	// Note: we call the info subcommand directly instead of via the wsCmd
+	// parent to avoid interference from persistent flag state across tests.
+	// The flag values are set by the cobra flag parser on the subcommand.
+	wsDeckRoot = root
+	wsJSON = false
+	var buf bytes.Buffer
+	wsInfoCmd.SetOut(&buf)
+	wsInfoCmd.SetErr(&buf)
+	if err := wsInfoCmd.RunE(wsInfoCmd, nil); err != nil {
+		t.Fatalf("ws info: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Workspace: local") {
+		t.Errorf("ws info missing 'Workspace: local': %q", out)
+	}
+	if !strings.Contains(out, "Decks:     1") {
+		t.Errorf("ws info missing 'Decks:     1': %q", out)
+	}
+}
+
+// TestWsInfoJSON verifies the --json output of `slyds ws info` has the
+// expected shape: root, deck_count, kind. Locks the schema so scripts
+// (including the Makefile smoke test) can parse it reliably.
+func TestWsInfoJSON(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("JSON Test", 2, "default", filepath.Join(root, "alpha"), true)
+	core.CreateInDir("JSON Test 2", 3, "dark", filepath.Join(root, "beta"), true)
+
+	wsDeckRoot = root
+	wsJSON = true
+	defer func() { wsJSON = false }()
+	var buf bytes.Buffer
+	wsInfoCmd.SetOut(&buf)
+	wsInfoCmd.SetErr(&buf)
+	if err := wsInfoCmd.RunE(wsInfoCmd, nil); err != nil {
+		t.Fatalf("ws info --json: %v", err)
+	}
+
+	var info map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &info); err != nil {
+		t.Fatalf("ws info --json is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if info["kind"] != "local" {
+		t.Errorf("kind = %v, want \"local\"", info["kind"])
+	}
+	if info["deck_count"].(float64) != 2 {
+		t.Errorf("deck_count = %v, want 2", info["deck_count"])
+	}
+	if info["root"] == "" {
+		t.Error("root should be set")
+	}
+}
+
+// TestWsListJSON verifies that `slyds ws list --json` returns the same
+// shape as the MCP list_decks tool. This is the contract that makes the
+// CLI and MCP tool output interchangeable for scripting.
+func TestWsListJSON(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Alpha", 3, "default", filepath.Join(root, "alpha"), true)
+	core.CreateInDir("Beta", 5, "dark", filepath.Join(root, "beta"), true)
+
+	wsDeckRoot = root
+	wsJSON = true
+	defer func() { wsJSON = false }()
+	var buf bytes.Buffer
+	wsListCmd.SetOut(&buf)
+	wsListCmd.SetErr(&buf)
+	if err := wsListCmd.RunE(wsListCmd, nil); err != nil {
+		t.Fatalf("ws list --json: %v", err)
+	}
+
+	var summaries []deckSummary
+	if err := json.Unmarshal(buf.Bytes(), &summaries); err != nil {
+		t.Fatalf("ws list --json is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(summaries) != 2 {
+		t.Fatalf("expected 2 decks, got %d", len(summaries))
+	}
+
+	got := map[string]deckSummary{}
+	for _, s := range summaries {
+		got[s.Name] = s
+	}
+	if got["alpha"].Title != "Alpha" || got["alpha"].Slides != 3 || got["alpha"].Theme != "default" {
+		t.Errorf("alpha mismatch: %+v", got["alpha"])
+	}
+	if got["beta"].Title != "Beta" || got["beta"].Slides != 5 || got["beta"].Theme != "dark" {
+		t.Errorf("beta mismatch: %+v", got["beta"])
+	}
+}
+
+// TestWsListEmpty verifies the human-readable empty-workspace output is
+// "(no decks)" — so a human running `slyds ws list` in an empty dir gets
+// a clear message instead of silent output.
+func TestWsListEmpty(t *testing.T) {
+	wsDeckRoot = t.TempDir()
+	wsJSON = false
+	var buf bytes.Buffer
+	wsListCmd.SetOut(&buf)
+	wsListCmd.SetErr(&buf)
+	if err := wsListCmd.RunE(wsListCmd, nil); err != nil {
+		t.Fatalf("ws list: %v", err)
+	}
+	if !strings.Contains(buf.String(), "(no decks)") {
+		t.Errorf("empty workspace should say '(no decks)': %q", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Decouple MCP tool and resource handlers from raw `--deck-root` filesystem paths by introducing a `Workspace` abstraction. Handlers now resolve decks via `workspaceFromContext(ctx).OpenDeck(name)` — never from captured paths. The active workspace is installed on every request by an mcpkit middleware: today a single `LocalWorkspace` constructed at server startup; tomorrow a per-request workspace built from authentication.

**Zero behavioral changes visible to MCP clients.** Tool arguments, resource URIs, and response shapes are unchanged. Existing agents keep working.

This is PR 1 of 4 for issue #74. Follow-ups are tracked as separate issues (#78 slug-as-ID, #79 optimistic versioning, #80 multi-root workspace.yaml, #81 preview cache tenancy).

## Why now

slyds is the first concrete consumer that will grow toward hosted multi-tenant MCP (#76). Without this abstraction, every future direction forks the codebase:

- Hosted multi-tenancy requires per-request workspace resolution from auth — not a startup-time constant
- Optimistic concurrency (#79) needs a clean boundary for versioning and locking
- Multi-root power-user setups (#80) need a unified handle over multiple roots
- Tenant isolation would leak if tool handlers could construct `Deck` from raw paths at will

Landing the abstraction first keeps every follow-up a clean, small diff on top of shared plumbing.

## Design

### `Workspace` interface (`cmd/workspace.go`)

```go
type Workspace interface {
    OpenDeck(name string) (*core.Deck, error)
    ListDecks() ([]DeckRef, error)
    CreateDeck(name, title, theme string, slides int) (*core.Deck, error)
}
```

Minimum viable. `Locker()`, `Identity()`, `Topic()` are deferred until the features that need them land (#79, #81, mcpkit#187).

### `LocalWorkspace` wiring

- Constructed once in `runMCPServer()` from `--deck-root`
- Installed on every request by `workspaceMiddleware` (an mcpkit `server.Middleware`)
- Tool handlers call `workspaceFromContext(ctx)` to retrieve it
- Unit tests install via `withWorkspace(ctx, ws)` helper

### Validation

`validateDeckName` rejects path separators (`/`, `\`) and leading dots before any filesystem access. Reserves `/` for future multi-root qualification (`root/deck`).

### Error mapping

`OpenDeck` returns `ErrDeckNotFound` for both "missing" and "filesystem error" cases. Uniform mapping matters for future hosted workspaces where leaking "exists but unauthorized" vs "doesn't exist" is a tenancy information leak.

## New `slyds ws` CLI

```bash
slyds ws info --deck-root DIR     # workspace root, deck count
slyds ws list --deck-root DIR     # human-readable deck list
slyds ws list --json              # structured output matching MCP list_decks
```

Debug/introspection subcommand that exercises the same `LocalWorkspace` path the MCP server uses. Doubles as a smoke test for the wiring — humans can verify the workspace without running a JSON-RPC client.

## New `make demo-smoke` target

End-to-end smoke test that drives both the CLI workspace path AND the MCP middleware path through a single verification:

1. Scaffolds the demo deck set
2. Runs `slyds ws info` and `slyds ws list` (human + JSON)
3. Starts `slyds mcp` in the background
4. Performs MCP `initialize` + `tools/call list_decks` via curl
5. Asserts the curl response contains one of the demo decks
6. Cleans up

Proves that CLI `ws` and MCP `list_decks` agree on the deck set.

## Files

| File | Change |
|------|--------|
| `cmd/workspace.go` | **NEW** — `Workspace` interface, `LocalWorkspace`, middleware, context helpers |
| `cmd/workspace_test.go` | **NEW** — 11 unit tests for `LocalWorkspace` and middleware |
| `cmd/ws.go` | **NEW** — `slyds ws` CLI subcommand (`info`, `list`) |
| `cmd/ws_test.go` | **NEW** — 4 tests for the CLI subcommand |
| `cmd/mcp.go` | Construct `LocalWorkspace`, install middleware; `openDeck` + `discoverDecks` helpers removed |
| `cmd/mcp_tools.go` | 11 factories drop `root` parameter, use `openDeckFromContext` helper |
| `cmd/mcp_resources.go` | 7 handlers use `workspaceFromContext` + `openDeckForResource` twin |
| `cmd/mcp_apps.go` | `preview_deck` and `preview_slide` use workspace middleware |
| `cmd/mcp_tools_test.go` | Tests refactored to pass workspace via `callTool(t, root, ...)`, plus new `TestMCPTools_NoWorkspaceReturnsError` (11 subtests) |
| `cmd/mcp_resources_test.go` | `TestDiscoverDecks*` / `TestOpenDeck` removed (equivalent coverage in `workspace_test.go`); `TestResourceRegistration` migrated to workspace middleware |
| `cmd/mcp_apps_test.go` | `newSlydsMCPClientWithUI` + `extractAppTool` install workspace middleware |
| `cmd/mcp_e2e_test.go` | `newSlydsMCPClient` installs workspace middleware; `TestPerToolTimeout` drops root arg |
| `Makefile` | New `demo-smoke` target + entry in `.PHONY` |
| Docs | CLAUDE.md (Key files, Conventions, Gotchas), ARCHITECTURE.md (new Workspace layer subsection), ROADMAP.md (Phase 9h entry), NEXTSTEPS.md (checked off + 3 follow-ups) |

## Test plan

- [x] Red-before-green: 11 `TestLocalWorkspace_*` tests written first, confirmed green after implementation
- [x] `TestMCPTools_NoWorkspaceReturnsError` — 11 tools × 3 assertions = 33 new assertions, ensures no nil-pointer panics if middleware is ever accidentally removed
- [x] All existing E2E tests unchanged, all passing (`TestE2E_FullAgentWorkflow`, `TestE2E_ToolCallTyped`, `TestE2E_ListDecks`, `TestE2E_StdioTransport`, `TestE2E_PreviewDeckResource`, etc.)
- [x] `make demo-smoke` — CLI `ws` and MCP `list_decks` return the same 3 demo decks
- [x] Pre-push hook (`make test`) passes
- [x] Constraint check: no new regex HTML mutation in `cmd/` (only legacy `slides.go:26` include parser)

### Assertion audit

- **Added**: ~81 new assertions (49 in `workspace_test.go`, 32 in `ws_test.go`, 33 in `TestMCPTools_NoWorkspaceReturnsError`)
- **Removed**: 11 assertions from 4 deleted tests (`TestDiscoverDecks`, `TestDiscoverDecksEmpty`, `TestDiscoverDecksRootIsDeck`, `TestOpenDeck`), each replaced 1:1 by equivalent-or-stricter `LocalWorkspace_*` tests
- **Weakened**: **0** — every existing E2E test keeps identical assertions

## Non-goals (tracked as follow-ups)

| Follow-up | Issue | Rationale |
|-----------|-------|-----------|
| Slug-as-ID in `slide_ref` + slug uniqueness | #78 | Independent API change, own test surface |
| Optimistic versioning on mutations | #79 | New error type + Locker interface, much bigger test matrix |
| Multi-root `workspace.yaml` config | #80 | Power-user feature, deferred until requested |
| `previewCache` tenant scoping | #81 | Latent bug found during exploration, blocks hosted rollout |

mcpkit resource-topic notification routing (mcpkit#187) is the upstream dependency for fine-grained per-resource notifications — tracked separately, not required for this PR.

## What's NOT in this PR

- CLI commands (`build`, `check`, `describe`, `slides`, `query`, `preview`, `init`) — unchanged, still use `core.OpenDeckDir`. The Workspace is an MCP-server concern today.
- `core/` package — zero changes. `core.Deck` API is untouched.
- Examples — unchanged, still construct decks via `core.OpenDeck(templar.NewLocalFS(dir))` in tests.
- go.mod / dependencies — unchanged.

Closes #74 — partially (PR 1 of 4 sub-tasks).