### PR TITLE
feat: slug-as-ID in MCP tools + slug uniqueness (#78 — #74 PR 2/4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,6 +140,14 @@ The abstraction exists so that:
 
 The `slyds ws` CLI subcommand exercises the same `LocalWorkspace` implementation the MCP server uses, making it a single-process smoke test for the wiring.
 
+### Slide identity
+
+Slides have three overlapping identifiers: **position** (1-based, changes on insert/remove), **filename** (`NN-slug.html`, prefix changes on renumber), and **slug** (the non-prefix portion of the filename, stable across inserts/removes/moves because `RewriteSlideOrder` preserves it). Agents should prefer slug for references that survive position shifts.
+
+Slug uniqueness within a deck is enforced at every creation path — `InsertSlide` auto-suffixes on collision (`intro`, `intro-2`, `intro-3`), and the scaffolder produces unique slugs by default even for large decks (`01-title.html`, `02-slide.html`, `03-slide-2.html`, `04-slide-3.html`, `05-closing.html`). `ResolveSlide` accepts slug, filename, or position as a reference and returns `ErrAmbiguousSlideRef` if a reference matches more than one slide instead of silently picking the first match.
+
+Slug is the best "stable handle" the current file-based backend provides, but it is not truly rename-safe — running `slyds slides slugify` can change a slide's slug. A rename-safe `slide_id` stored in `.slyds.yaml` is planned as the next subtask of #74 (#83) so optimistic versioning (#79) can lock on an identifier that survives both position shifts and renames.
+
 **Model Context Protocol** (`cmd/mcp.go`, `cmd/mcp_tools.go`, `cmd/mcp_resources.go`, `cmd/mcp_apps.go`): uses **mcpkit** v0.1.15 (split packages: `core/`, `server/`) + **ext/ui** v0.1.15 (MCP Apps). Single-struct registration (`srv.Register`), workspace middleware, per-tool timeouts, `StructuredResult` for typed output, error handler for session lifecycle, EventStore for Streamable HTTP reconnection. Exposes **13 tools** (11 core + 2 preview) and **7 browsable resources** for reading deck content. Transports: Streamable HTTP (default), SSE (`--sse`), or stdio (`--stdio`). `--deck-root` sets the local workspace root. See [docs/MCP.md](docs/MCP.md).
 
 **Tools**: `list_decks`, `create_deck`, `describe_deck`, `list_slides`, `read_slide`, `edit_slide`, `query_slide`, `add_slide`, `remove_slide`, `check_deck`, `build_deck`, `preview_deck`, `preview_slide`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ All Deck I/O goes through `templar.WritableFS` (v0.1.0). No `os.*`/`filepath.*` 
 
 - **Deck is the single API** — cmd/ calls Deck methods, never touches FS internals
 - **Workspace is the MCP boundary** — MCP tool and resource handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`, never from raw paths. The workspace is installed on every request via `workspaceMiddleware`. See [cmd/workspace.go](cmd/workspace.go).
+- **Slug is the stable slide handle** — agents should reference slides by slug (the non-prefix portion of `NN-slug.html`), not by position, for identity across inserts/removes. Slug uniqueness is enforced at creation time via auto-suffixing (`intro`, `intro-2`, `intro-3`). `ResolveSlide` returns `ErrAmbiguousSlideRef` when a reference is ambiguous. Not rename-safe — a truly stable `slide_id` is planned in #83.
 - **No hardcoded HTML** — use embedded `.tmpl` files under `assets/templates/`
 - **No regex HTML mutation** — use `d.Query()` (goquery/CSS selectors). See [CONSTRAINTS.md](CONSTRAINTS.md)
 - **Index.html is source of truth** for slide ordering

--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -43,9 +43,10 @@
 - [x] ~~MCP Apps — inline slide previews via `preview_deck` and `preview_slide` tools (#64)~~
 - [x] ~~mcpkit v0.1.15 adoption — single-struct registration, per-tool timeouts, StructuredResult, error handler, EventStore (#71)~~
 - [x] ~~Workspace abstraction — `cmd/workspace.go`, `slyds ws` CLI, MCP middleware-based deck resolution (#74, PR 1 of 4)~~
-- [ ] Slug-as-ID in MCP tools + slug uniqueness (#74 subtask)
-- [ ] Optimistic versioning on MCP mutations (#74 subtask)
-- [ ] Multi-root workspace.yaml config (#74 subtask)
+- [x] ~~Slug-as-ID in MCP tools + slug uniqueness — `Slug` field, priority-chain `ResolveSlide`, scaffolder fix, `slide` param on read/edit (#78, #74 PR 2 of 4)~~
+- [ ] Persistent slide IDs in `.slyds.yaml` for rename-safe identity (#83, next subtask)
+- [ ] Optimistic versioning on MCP mutations (#79, locks on slide_id)
+- [ ] Multi-root workspace.yaml config (#80)
 - [ ] Slide folders with co-located assets (e.g., `slides/03-architecture/slide.html` + `diagram.png`)
 - [ ] Live reload on file changes during `slyds serve`
 - [ ] Theme composability via templar `extend`/`namespace` directives

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ scaling-at-the-edge/
   theme.css               # Your color/style overrides
   slides/
     01-title.html          # Title slide
-    02-slide.html          # Content slides
-    03-slide.html
-    04-slide.html
+    02-slide.html          # Content slides (each has a unique slug:
+    03-slide-2.html        # slide, slide-2, slide-3, ...)
+    04-slide-3.html
     05-closing.html        # Closing slide
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,9 @@ Adopted mcpkit v0.1.15 features: single-struct registration (`srv.Register` with
 ## Phase 9h — Workspace abstraction (done)
 Introduced a `Workspace` interface (`cmd/workspace.go`) to decouple MCP tool and resource handlers from raw `--deck-root` filesystem paths. The `LocalWorkspace` implementation is installed on every MCP request via `workspaceMiddleware`; handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`. New `slyds ws` CLI subcommand (`ws info`, `ws list`) exercises the same workspace path as the MCP server, and `make demo-smoke` drives both through a single end-to-end test. This is the prep refactor for hosted multi-tenancy (#76), optimistic concurrency, and slug-as-ID slide identity — all tracked as follow-ups under #74. No behavioral changes for existing agents or CLI users.
 
+## Phase 9i — Slug-as-ID in MCP tools (done)
+Made slug (the non-prefix portion of `NN-slug.html`) the stable handle for slide references in the MCP API. `SlideDescription` grew a `Slug` field returned by `describe_deck` / `list_slides`. `ResolveSlide` rewritten with a priority chain (numeric → exact filename → exact slug → substring fallback) and new `ErrAmbiguousSlideRef` for multi-match cases. `InsertSlide` auto-suffixes colliding slugs via the same `-N` pattern `SlugifySlides` already uses, and now returns `(finalSlug, error)` so callers can surface the actual name. Scaffolder fixed so `slyds init --slides 5` produces unique slugs by default (`slide`, `slide-2`, `slide-3`). MCP `read_slide` and `edit_slide` accept a new `slide` string parameter (slug, filename, or position) alongside the existing `position` int for backward compat. `TestE2E_SlugRefSurvivesInsert` is the canonical integration test proving slug stability across position shifts.
+
 ## Phase 10 — Slide Folders
 Support `slides/03-name/slide.html` with co-located assets (images, per-slide CSS). Auto-detect folder vs file slides.
 

--- a/cmd/mcp_e2e_test.go
+++ b/cmd/mcp_e2e_test.go
@@ -355,6 +355,92 @@ func TestPerToolTimeout(t *testing.T) {
 	}
 }
 
+// TestE2E_SlugRefSurvivesInsert is the canonical integration test for
+// slug-as-ID (#78): it proves that a slug-based `slide` reference remains
+// stable across a structural mutation that shifts position numbers.
+//
+// The flow:
+//
+//  1. Scaffold a 5-slide deck (slugs: title, slide, slide-2, slide-3, closing).
+//  2. Edit the slide at slug "slide-2" via edit_slide — originally at position 3.
+//  3. Insert a new slide at position 2 via add_slide, shifting every later
+//     slide's position number up by one. "slide-2" is now at position 4.
+//  4. Edit again by slug "slide-2". If slug is truly stable, the second edit
+//     lands on the same file as the first — not on whatever is at position 3
+//     now. Content from both edits should be present in the final read.
+//
+// This test exists to prove that the whole PR's motivation works end-to-end.
+// If it fails, slug identity is broken.
+func TestE2E_SlugRefSurvivesInsert(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Slug Stability", 5, "default", fmt.Sprintf("%s/test-deck", root), true)
+
+	c := newSlydsMCPClient(t, root)
+
+	// 1. First edit by slug — lands at position 3 in the 5-slide deck.
+	firstEdit := `<div class="slide" data-layout="content"><h1>First Edit</h1><p class="marker-1"></p></div>`
+	r := c.ToolCall("edit_slide", map[string]any{
+		"deck":    "test-deck",
+		"slide":   "slide-2",
+		"content": firstEdit,
+	})
+	if !strings.Contains(r, "updated") {
+		t.Fatalf("first edit_slide: %s", r)
+	}
+
+	// Read by slug and verify the first edit landed.
+	content := c.ToolCall("read_slide", map[string]any{
+		"deck":  "test-deck",
+		"slide": "slide-2",
+	})
+	if !strings.Contains(content, "First Edit") {
+		t.Fatalf("first edit content not found: %s", content)
+	}
+
+	// 2. Insert a new slide at position 2. The original "slide-2" shifts
+	//    to position 4; its filename becomes 04-slide-2.html.
+	r = c.ToolCall("add_slide", map[string]any{
+		"deck": "test-deck", "position": 2, "name": "inserted", "layout": "content",
+	})
+	if !strings.Contains(r, "inserted at position 2") {
+		t.Fatalf("add_slide: %s", r)
+	}
+
+	// 3. Edit by slug "slide-2" AGAIN — should still land on the same
+	//    original slide, now at position 4. The first edit's content
+	//    must still be present (we didn't clobber it), and the second
+	//    edit's content must be appended over.
+	secondEdit := `<div class="slide" data-layout="content"><h1>Second Edit</h1><p class="marker-2"></p></div>`
+	r = c.ToolCall("edit_slide", map[string]any{
+		"deck":    "test-deck",
+		"slide":   "slide-2",
+		"content": secondEdit,
+	})
+	if !strings.Contains(r, "updated") {
+		t.Fatalf("second edit_slide: %s", r)
+	}
+
+	// 4. Read by slug — must return the second edit's content, proving
+	//    the slug reference stayed pointed at the same file across the
+	//    position shift.
+	content = c.ToolCall("read_slide", map[string]any{
+		"deck":  "test-deck",
+		"slide": "slide-2",
+	})
+	if !strings.Contains(content, "Second Edit") {
+		t.Errorf("second edit by slug didn't land on the original slide: %s", content)
+	}
+
+	// Sanity: position 2 now holds the newly inserted slide, NOT slide-2.
+	content = c.ToolCall("read_slide", map[string]any{
+		"deck":     "test-deck",
+		"position": 2,
+	})
+	if strings.Contains(content, "Second Edit") || strings.Contains(content, "marker-2") {
+		t.Error("the second edit accidentally landed at position 2 (the inserted slide)")
+	}
+}
+
 // TestE2E_StdioTransport verifies that the slyds MCP server works over the
 // stdio transport (Content-Length framed JSON-RPC over stdin/stdout). This test
 // creates a server with all tools and resources registered, wires it to a pair

--- a/cmd/mcp_tools.go
+++ b/cmd/mcp_tools.go
@@ -193,19 +193,21 @@ func readSlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "read_slide",
-			Description: "Read the raw HTML content of a slide by position (1-based).",
+			Description: "Read the raw HTML content of a slide. Supply either 'slide' (preferred: slug, filename, or position as string) or 'position' (legacy: 1-based integer).",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"deck":     propString("Deck name (workspace-scoped identifier)"),
-					"position": propInt("Slide position (1-based)"),
+					"slide":    propString("Slide reference: slug (e.g. 'metrics'), filename (e.g. '02-metrics.html'), or position number as string"),
+					"position": propInt("Slide position (1-based). Legacy — prefer 'slide' for stability across inserts."),
 				},
-				"required": []string{"deck", "position"},
+				"required": []string{"deck"},
 			},
 		},
 		Handler: func(ctx context.Context, req mcpcore.ToolRequest) (mcpcore.ToolResult, error) {
 			var p struct {
 				Deck     string `json:"deck"`
+				Slide    string `json:"slide"`
 				Position int    `json:"position"`
 			}
 			if err := req.Bind(&p); err != nil {
@@ -215,7 +217,11 @@ func readSlideTool() server.Tool {
 			if errResult != nil {
 				return *errResult, nil
 			}
-			content, err := d.GetSlideContent(p.Position)
+			pos, err := resolveSlidePosition(d, p.Slide, p.Position)
+			if err != nil {
+				return mcpcore.ErrorResult(err.Error()), nil
+			}
+			content, err := d.GetSlideContent(pos)
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
@@ -228,20 +234,22 @@ func editSlideTool() server.Tool {
 	return server.Tool{
 		ToolDef: mcpcore.ToolDef{
 			Name:        "edit_slide",
-			Description: "Replace the HTML content of a slide at the given position.",
+			Description: "Replace the HTML content of a slide. Supply either 'slide' (preferred: slug, filename, or position as string) or 'position' (legacy: 1-based integer).",
 			InputSchema: map[string]any{
 				"type": "object",
 				"properties": map[string]any{
 					"deck":     propString("Deck name"),
-					"position": propInt("Slide position (1-based)"),
+					"slide":    propString("Slide reference: slug (e.g. 'metrics'), filename (e.g. '02-metrics.html'), or position number as string"),
+					"position": propInt("Slide position (1-based). Legacy — prefer 'slide' for stability across inserts."),
 					"content":  propString("New HTML content for the slide"),
 				},
-				"required": []string{"deck", "position", "content"},
+				"required": []string{"deck", "content"},
 			},
 		},
 		Handler: func(ctx context.Context, req mcpcore.ToolRequest) (mcpcore.ToolResult, error) {
 			var p struct {
 				Deck     string `json:"deck"`
+				Slide    string `json:"slide"`
 				Position int    `json:"position"`
 				Content  string `json:"content"`
 			}
@@ -252,13 +260,46 @@ func editSlideTool() server.Tool {
 			if errResult != nil {
 				return *errResult, nil
 			}
-			if err := d.EditSlideContent(p.Position, p.Content); err != nil {
+			pos, err := resolveSlidePosition(d, p.Slide, p.Position)
+			if err != nil {
+				return mcpcore.ErrorResult(err.Error()), nil
+			}
+			if err := d.EditSlideContent(pos, p.Content); err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
 			mcpcore.NotifyResourcesChanged(ctx)
-			return mcpcore.TextResult(fmt.Sprintf("Slide %d updated.", p.Position)), nil
+			return mcpcore.TextResult(fmt.Sprintf("Slide %d updated.", pos)), nil
 		},
 	}
+}
+
+// resolveSlidePosition turns the (slide, position) parameter pair from
+// read_slide / edit_slide into a concrete 1-based position. The `slide`
+// string takes precedence over `position` if both are provided; this
+// lets agents migrate from position-based refs to slug-based refs on
+// their own schedule. Returns a descriptive error if neither is set or
+// the slide string cannot be resolved.
+func resolveSlidePosition(d *core.Deck, slide string, position int) (int, error) {
+	if slide != "" {
+		filename, err := d.ResolveSlide(slide)
+		if err != nil {
+			return 0, err
+		}
+		slides, err := d.SlideFilenames()
+		if err != nil {
+			return 0, err
+		}
+		for i, s := range slides {
+			if s == filename {
+				return i + 1, nil
+			}
+		}
+		return 0, fmt.Errorf("resolved slide %q (%s) not found in deck ordering", slide, filename)
+	}
+	if position >= 1 {
+		return position, nil
+	}
+	return 0, fmt.Errorf("either 'slide' or 'position' is required")
 }
 
 func querySlideTool() server.Tool {
@@ -362,10 +403,17 @@ func addSlideTool() server.Tool {
 			if errResult != nil {
 				return *errResult, nil
 			}
-			if err := d.InsertSlide(p.Position, p.Name, p.Layout, p.Title); err != nil {
+			finalSlug, err := d.InsertSlide(p.Position, p.Name, p.Layout, p.Title)
+			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
 			mcpcore.NotifyResourcesChanged(ctx)
+			if finalSlug != p.Name {
+				return mcpcore.TextResult(fmt.Sprintf(
+					"Slide %q inserted at position %d (slug auto-suffixed to %q to avoid collision).",
+					p.Name, p.Position, finalSlug,
+				)), nil
+			}
 			return mcpcore.TextResult(fmt.Sprintf("Slide %q inserted at position %d.", p.Name, p.Position)), nil
 		},
 	}
@@ -380,7 +428,7 @@ func removeSlideTool() server.Tool {
 				"type": "object",
 				"properties": map[string]any{
 					"deck":  propString("Deck name"),
-					"slide": propString("Slide filename (e.g. '02-slide.html') or position number"),
+					"slide": propString("Slide reference: slug (e.g. 'metrics'), filename (e.g. '02-metrics.html'), or position number as string"),
 				},
 				"required": []string{"deck", "slide"},
 			},

--- a/cmd/mcp_tools_test.go
+++ b/cmd/mcp_tools_test.go
@@ -271,6 +271,103 @@ func TestToolDeckNotFound(t *testing.T) {
 	}
 }
 
+// TestReadSlideTool_BySlideParam verifies that read_slide accepts a
+// slug-based reference via the new `slide` string parameter in addition
+// to the legacy `position` int. Uses a scaffolded 3-slide deck (slugs:
+// title, slide, closing) and reads slide 2 by slug.
+func TestReadSlideTool_BySlideParam(t *testing.T) {
+	root := scaffoldTestDeck(t, "test-deck", "Slide Test", "default", 3)
+	tool := readSlideTool()
+
+	result := callTool(t, root, tool.Handler, map[string]any{
+		"deck":  "test-deck",
+		"slide": "slide", // slug of the middle content slide
+	})
+	if result.IsError {
+		t.Fatalf("read_slide by slide: %s", toolText(result))
+	}
+	if !strings.Contains(toolText(result), `data-layout="content"`) {
+		t.Error("read_slide by slug didn't return the content slide")
+	}
+}
+
+// TestEditSlideTool_BySlideParam verifies that edit_slide accepts a
+// slug-based reference and lands the mutation on the right slide.
+func TestEditSlideTool_BySlideParam(t *testing.T) {
+	root := scaffoldTestDeck(t, "test-deck", "Edit by Slug", "default", 3)
+	editTool := editSlideTool()
+	readTool := readSlideTool()
+
+	newContent := `<div class="slide" data-layout="content"><h1>Edited by Slug</h1></div>`
+	result := callTool(t, root, editTool.Handler, map[string]any{
+		"deck":    "test-deck",
+		"slide":   "slide",
+		"content": newContent,
+	})
+	if result.IsError {
+		t.Fatalf("edit_slide by slide: %s", toolText(result))
+	}
+
+	result = callTool(t, root, readTool.Handler, map[string]any{
+		"deck":     "test-deck",
+		"position": 2,
+	})
+	if !strings.Contains(toolText(result), "Edited by Slug") {
+		t.Error("edit via slide ref didn't persist")
+	}
+}
+
+// TestEditSlideTool_RequiresPositionOrSlide verifies that edit_slide
+// returns a clear error when the caller supplies neither `slide` nor
+// `position`. Guards against agents accidentally sending empty refs.
+func TestEditSlideTool_RequiresPositionOrSlide(t *testing.T) {
+	root := scaffoldTestDeck(t, "test-deck", "Req Test", "default", 3)
+	tool := editSlideTool()
+
+	result := callTool(t, root, tool.Handler, map[string]any{
+		"deck":    "test-deck",
+		"content": "<div>x</div>",
+	})
+	if !result.IsError {
+		t.Error("expected error when neither slide nor position provided")
+	}
+	if !strings.Contains(toolText(result), "required") {
+		t.Errorf("error should say 'required'; got: %s", toolText(result))
+	}
+}
+
+// TestAddSlideTool_SlugCollision verifies that add_slide auto-suffixes a
+// colliding slug and surfaces the actual slug used in the response text.
+// Two consecutive inserts with name="intro" produce intro and intro-2;
+// the second call's response must mention the auto-suffix.
+func TestAddSlideTool_SlugCollision(t *testing.T) {
+	root := scaffoldTestDeck(t, "test-deck", "Collision", "default", 3)
+	addTool := addSlideTool()
+
+	// First insert: slug "intro" is free.
+	r1 := callTool(t, root, addTool.Handler, map[string]any{
+		"deck": "test-deck", "position": 2, "name": "intro", "layout": "content",
+	})
+	if r1.IsError {
+		t.Fatalf("first add: %s", toolText(r1))
+	}
+
+	// Second insert: slug "intro" now collides, should become intro-2.
+	r2 := callTool(t, root, addTool.Handler, map[string]any{
+		"deck": "test-deck", "position": 3, "name": "intro", "layout": "content",
+	})
+	if r2.IsError {
+		t.Fatalf("second add: %s", toolText(r2))
+	}
+	msg := toolText(r2)
+	if !strings.Contains(msg, "intro-2") {
+		t.Errorf("second add response should mention intro-2; got: %s", msg)
+	}
+	if !strings.Contains(msg, "auto-suffixed") {
+		t.Errorf("second add response should mention auto-suffix; got: %s", msg)
+	}
+}
+
 // TestMCPTools_NoWorkspaceReturnsError verifies that every tool handler
 // returns a clean error (instead of panicking) when invoked with a context
 // that has no workspace installed. This prevents silent nil-pointer bugs

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -52,8 +52,12 @@ var addCmd = &cobra.Command{
 		}
 
 		layoutName := resolveLayoutFlag(slideLayout, slideType)
-		if err := d.InsertSlide(position, name, layoutName, ""); err != nil {
+		finalName, err := d.InsertSlide(position, name, layoutName, "")
+		if err != nil {
 			return err
+		}
+		if finalName != name {
+			fmt.Fprintf(os.Stderr, "note: slide name auto-suffixed to avoid slug collision: %s\n", finalName)
 		}
 
 		if slotsFileAdd != "" {
@@ -227,8 +231,12 @@ after insertion to maintain consistent NN-name.html naming.`,
 		}
 
 		layoutName := resolveLayoutFlag(insertLayout, insertType)
-		if err := d.InsertSlide(pos, name, layoutName, insertTitle); err != nil {
+		finalName, err := d.InsertSlide(pos, name, layoutName, insertTitle)
+		if err != nil {
 			return err
+		}
+		if finalName != name {
+			fmt.Fprintf(os.Stderr, "note: slide name auto-suffixed to avoid slug collision: %s\n", finalName)
 		}
 
 		if slotsFileInsert != "" {

--- a/cmd/slides_test.go
+++ b/cmd/slides_test.go
@@ -17,7 +17,8 @@ func runInsert(root string, pos int, name, layoutName, title string) error {
 	if err != nil {
 		return err
 	}
-	return d.InsertSlide(pos, name, layoutName, title)
+	_, err = d.InsertSlide(pos, name, layoutName, title)
+	return err
 }
 
 // mustSlideFilenames opens a Deck and returns its slide filenames.

--- a/core/deck.go
+++ b/core/deck.go
@@ -286,12 +286,23 @@ func (d *Deck) SlugifySlides(slugFn func(string) string) (int, error) {
 	return renamed, d.RewriteSlideOrder(newNames)
 }
 
-// InsertSlide renders a new slide from the named layout template and inserts it
-// at the given position. This is the high-level "add a slide" operation that
-// combines layout rendering with slide insertion.
-// The name is used to generate the filename slug. Title overrides the display title.
-func (d *Deck) InsertSlide(position int, name, layoutName, title string) error {
-	displayName := slugToTitle(name)
+// InsertSlide renders a new slide from the named layout template and inserts
+// it at the given position. The name is used to generate the filename slug.
+// If a slide with the same slug already exists in the deck, the slug is
+// auto-suffixed with -2, -3, ... (same convention as SlugifySlides) to keep
+// slugs unique within a deck.
+//
+// Returns the final slug actually used (may differ from the requested name
+// if auto-suffix was applied) and any error encountered.
+//
+// Title overrides the display title (otherwise derived from the slug).
+//
+// TODO(#83): also return assigned slide_id once .slyds.yaml stores per-slide
+// metadata — gives callers a rename-safe handle separate from the slug.
+func (d *Deck) InsertSlide(position int, name, layoutName, title string) (string, error) {
+	finalName := d.uniqueSlug(name)
+
+	displayName := slugToTitle(finalName)
 	if title != "" {
 		displayName = title
 	}
@@ -301,11 +312,36 @@ func (d *Deck) InsertSlide(position int, name, layoutName, title string) error {
 		"Number": position,
 	})
 	if err != nil {
-		return fmt.Errorf("layout %q: %w", layoutName, err)
+		return "", fmt.Errorf("layout %q: %w", layoutName, err)
 	}
 
-	filename := fmt.Sprintf("%02d-%s.html", position, name)
-	return d.AddSlide(position, filename, content)
+	filename := fmt.Sprintf("%02d-%s.html", position, finalName)
+	if err := d.AddSlide(position, filename, content); err != nil {
+		return "", err
+	}
+	return finalName, nil
+}
+
+// uniqueSlug returns the desired slug if no existing slide uses it, otherwise
+// appends -2, -3, ... until an unused slug is found. Uses the same convention
+// as SlugifySlides so the two creation paths stay consistent. A collision-free
+// name is always returned — the loop terminates because slide counts are
+// bounded by the filesystem.
+func (d *Deck) uniqueSlug(desired string) string {
+	used := map[string]bool{}
+	slides, _ := d.SlideFilenames()
+	for _, f := range slides {
+		used[strings.TrimSuffix(ExtractNamePart(f), ".html")] = true
+	}
+	if !used[desired] {
+		return desired
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s-%d", desired, i)
+		if !used[candidate] {
+			return candidate
+		}
+	}
 }
 
 // ApplySlots sets inner HTML for named layout slots on a slide.

--- a/core/deck_test.go
+++ b/core/deck_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -355,7 +356,7 @@ func TestInsertSlideWithLayout(t *testing.T) {
 	mfs.SetFile("slides/01-title.html", []byte(`<h1>Title</h1>`))
 
 	d, _ := OpenDeck(mfs)
-	if err := d.InsertSlide(2, "details", "content", ""); err != nil {
+	if _, err := d.InsertSlide(2, "details", "content", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -375,7 +376,7 @@ func TestInsertSlideWithTwoCol(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	d.InsertSlide(2, "comparison", "two-col", "")
+	_, _ = d.InsertSlide(2, "comparison", "two-col", "")
 
 	content, _ := d.GetSlideContent(2)
 	if !strings.Contains(content, `data-layout="two-col"`) {
@@ -396,7 +397,7 @@ func TestInsertSlideWithTitle(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	d.InsertSlide(1, "intro", "title", "Welcome Everyone")
+	_, _ = d.InsertSlide(1, "intro", "title", "Welcome Everyone")
 
 	content, _ := d.GetSlideContent(1)
 	if !strings.Contains(content, "Welcome Everyone") {
@@ -414,7 +415,7 @@ func TestInsertSlideUnknownLayout(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	err := d.InsertSlide(2, "bad", "nonexistent-layout", "")
+	_, err := d.InsertSlide(2, "bad", "nonexistent-layout", "")
 	if err == nil {
 		t.Fatal("expected error for unknown layout")
 	}
@@ -427,7 +428,7 @@ func TestApplySlots(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	d.InsertSlide(2, "details", "content", "")
+	_, _ = d.InsertSlide(2, "details", "content", "")
 
 	err := d.ApplySlots(2, map[string]string{
 		"body": "<p>Custom body content</p>",
@@ -494,5 +495,222 @@ func TestResolveSlide(t *testing.T) {
 	_, err = d.ResolveSlide("nope")
 	if err == nil {
 		t.Error("expected error for unknown slide")
+	}
+}
+
+// --- Slug-as-ID tests (#78) ---
+
+// makeDeckWithSlugs constructs an in-memory deck where slide filenames and
+// slug portions are fully under test control. Used by the slug-focused
+// tests below to create ambiguous or handcrafted slug states that a real
+// scaffolder wouldn't produce.
+func makeDeckWithSlugs(t *testing.T, slides ...string) *Deck {
+	t.Helper()
+	mfs := templar.NewMemFS()
+	var includes []byte
+	for _, f := range slides {
+		includes = append(includes, []byte(`{{# include "slides/`+f+`" #}}`+"\n")...)
+		mfs.SetFile("slides/"+f, []byte(`<section><h1>`+f+`</h1></section>`))
+	}
+	mfs.SetFile("index.html", includes)
+	d, err := OpenDeck(mfs)
+	if err != nil {
+		t.Fatalf("OpenDeck: %v", err)
+	}
+	return d
+}
+
+// TestInsertSlide_ReturnsFinalName verifies the InsertSlide signature
+// change: returns (finalName, error) so callers can see whether the
+// requested name was used verbatim or auto-suffixed. Exercises the
+// non-colliding happy path where the requested name is preserved.
+func TestInsertSlide_ReturnsFinalName(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
+
+	finalName, err := d.InsertSlide(2, "middle", "content", "Middle")
+	if err != nil {
+		t.Fatalf("InsertSlide: %v", err)
+	}
+	if finalName != "middle" {
+		t.Errorf("finalName = %q, want %q", finalName, "middle")
+	}
+
+	// The resulting filename should be 02-middle.html at position 2.
+	slides, _ := d.SlideFilenames()
+	if len(slides) != 3 {
+		t.Fatalf("slides = %d, want 3", len(slides))
+	}
+	if slides[1] != "02-middle.html" {
+		t.Errorf("slides[1] = %q, want 02-middle.html", slides[1])
+	}
+}
+
+// TestInsertSlide_SlugCollisionAutoSuffix verifies that InsertSlide
+// auto-suffixes the slug when it collides with an existing slide. This
+// is the core uniqueness rule — two slides can never share a slug within
+// a deck after this PR lands. The suffix pattern matches SlugifySlides
+// (intro → intro-2 → intro-3 → ...).
+func TestInsertSlide_SlugCollisionAutoSuffix(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
+
+	// Insert with a name that collides with the existing intro slide.
+	finalName, err := d.InsertSlide(3, "intro", "content", "Intro Two")
+	if err != nil {
+		t.Fatalf("InsertSlide: %v", err)
+	}
+	if finalName != "intro-2" {
+		t.Errorf("finalName = %q, want %q (auto-suffixed)", finalName, "intro-2")
+	}
+
+	slides, _ := d.SlideFilenames()
+	// Expect: 01-intro.html, 02-outro.html, 03-intro-2.html
+	if len(slides) != 3 {
+		t.Fatalf("slides = %d, want 3", len(slides))
+	}
+	if slides[0] != "01-intro.html" {
+		t.Errorf("slides[0] = %q, want 01-intro.html (original untouched)", slides[0])
+	}
+	if slides[2] != "03-intro-2.html" {
+		t.Errorf("slides[2] = %q, want 03-intro-2.html (suffixed)", slides[2])
+	}
+}
+
+// TestInsertSlide_SlugCollisionMultipleSuffix verifies that the -N counter
+// walks past existing suffixes. Given a deck with foo, foo-2, foo-3, an
+// InsertSlide call with name="foo" produces foo-4 (not foo-2 overwriting).
+func TestInsertSlide_SlugCollisionMultipleSuffix(t *testing.T) {
+	d := makeDeckWithSlugs(t,
+		"01-foo.html",
+		"02-foo-2.html",
+		"03-foo-3.html",
+	)
+
+	finalName, err := d.InsertSlide(4, "foo", "content", "")
+	if err != nil {
+		t.Fatalf("InsertSlide: %v", err)
+	}
+	if finalName != "foo-4" {
+		t.Errorf("finalName = %q, want foo-4", finalName)
+	}
+}
+
+// TestResolveSlide_BySlugExactMatch verifies that an exact slug (the
+// non-prefix portion of a filename) resolves to the right slide, even
+// when substring matching would return an earlier slide first.
+func TestResolveSlide_BySlugExactMatch(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
+
+	f, err := d.ResolveSlide("intro")
+	if err != nil {
+		t.Fatalf("ResolveSlide(intro): %v", err)
+	}
+	if f != "01-intro.html" {
+		t.Errorf("ResolveSlide(intro) = %q, want 01-intro.html", f)
+	}
+}
+
+// TestResolveSlide_BySlugAmbiguous verifies that a slug matching more
+// than one slide returns ErrAmbiguousSlideRef. Hand-crafts an ambiguous
+// state (two slides with slug "ambi") that the post-PR InsertSlide would
+// never produce — protects existing decks that shipped with duplicate
+// slugs before uniqueness was enforced.
+func TestResolveSlide_BySlugAmbiguous(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-ambi.html", "02-ambi.html")
+
+	_, err := d.ResolveSlide("ambi")
+	if err == nil {
+		t.Fatal("expected error for ambiguous slug")
+	}
+	if !errors.Is(err, ErrAmbiguousSlideRef) {
+		t.Errorf("expected ErrAmbiguousSlideRef, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "01-ambi.html") || !strings.Contains(msg, "02-ambi.html") {
+		t.Errorf("error should name both candidates, got: %v", err)
+	}
+}
+
+// TestResolveSlide_ByFilenameExact verifies that passing a full filename
+// (e.g., "01-intro.html") resolves to that exact file, distinct from the
+// slug-match and substring-match paths.
+func TestResolveSlide_ByFilenameExact(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
+
+	f, err := d.ResolveSlide("01-intro.html")
+	if err != nil {
+		t.Fatalf("ResolveSlide: %v", err)
+	}
+	if f != "01-intro.html" {
+		t.Errorf("got %q, want 01-intro.html", f)
+	}
+}
+
+// TestResolveSlide_ByPositionNumeric is a regression guard for the
+// existing numeric-ref path. Passing "2" resolves to the slide at
+// position 2 (1-based).
+func TestResolveSlide_ByPositionNumeric(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html", "03-closing.html")
+
+	f, err := d.ResolveSlide("2")
+	if err != nil {
+		t.Fatalf("ResolveSlide(2): %v", err)
+	}
+	if f != "02-outro.html" {
+		t.Errorf("ResolveSlide(2) = %q, want 02-outro.html", f)
+	}
+}
+
+// TestResolveSlide_BySubstringFallback verifies that the legacy substring
+// match still works for references that don't match a slug exactly. This
+// preserves backward compat for callers that pass partial filenames.
+func TestResolveSlide_BySubstringFallback(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-introduction.html", "02-outro.html")
+
+	// "ntro" doesn't match any slug exactly, but substring-matches
+	// 01-introduction.html. With only one match, resolution succeeds.
+	f, err := d.ResolveSlide("ntro")
+	if err != nil {
+		t.Fatalf("ResolveSlide(ntro): %v", err)
+	}
+	if f != "01-introduction.html" {
+		t.Errorf("got %q, want 01-introduction.html", f)
+	}
+}
+
+// TestResolveSlide_BySubstringAmbiguous verifies that substring matches
+// are now checked for ambiguity. Before this PR, strings.Contains picked
+// the first match silently; after, multiple matches return an error.
+// This is a strict improvement — the previous behavior was already wrong.
+func TestResolveSlide_BySubstringAmbiguous(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-retrospective.html")
+
+	// "tro" substring-matches both files.
+	_, err := d.ResolveSlide("tro")
+	if err == nil {
+		t.Fatal("expected error for ambiguous substring match")
+	}
+	if !errors.Is(err, ErrAmbiguousSlideRef) {
+		t.Errorf("expected ErrAmbiguousSlideRef, got %v", err)
+	}
+}
+
+// TestDescribe_IncludesSlug verifies that Describe() populates the Slug
+// field on every SlideDescription. Slug is derived from the filename by
+// stripping the NN- prefix and the .html suffix.
+func TestDescribe_IncludesSlug(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-metrics.html", "03-closing.html")
+
+	desc, err := d.Describe()
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	want := []string{"intro", "metrics", "closing"}
+	if len(desc.Slides) != len(want) {
+		t.Fatalf("slides = %d, want %d", len(desc.Slides), len(want))
+	}
+	for i, s := range desc.Slides {
+		if s.Slug != want[i] {
+			t.Errorf("slides[%d].Slug = %q, want %q", i, s.Slug, want[i])
+		}
 	}
 }

--- a/core/describe.go
+++ b/core/describe.go
@@ -18,9 +18,20 @@ type DeckDescription struct {
 }
 
 // SlideDescription holds metadata for a single slide.
+//
+// Slug is the stable, human-readable identifier for a slide within a deck.
+// It's derived from the filename by stripping the NN- prefix and .html
+// suffix. Stable across inserts/removes/moves (because RewriteSlideOrder
+// preserves the slug portion when renumbering) but NOT across renames
+// (slugify, manual rename). Agents should prefer Slug over Position when
+// referencing a slide across multiple MCP calls.
+//
+// TODO(#83): add SlideID field once .slyds.yaml stores per-slide metadata.
+// SlideID will be rename-safe where Slug is not.
 type SlideDescription struct {
 	Position int    `yaml:"position" json:"position"`
 	File     string `yaml:"file" json:"file"`
+	Slug     string `yaml:"slug" json:"slug"`
 	Layout   string `yaml:"layout" json:"layout"`
 	Title    string `yaml:"title" json:"title"`
 	Words    int    `yaml:"words" json:"words"`
@@ -66,6 +77,7 @@ func (d *Deck) Describe() (*DeckDescription, error) {
 		slideDescs = append(slideDescs, SlideDescription{
 			Position: i + 1,
 			File:     f,
+			Slug:     strings.TrimSuffix(ExtractNamePart(f), ".html"),
 			Layout:   slideLayout,
 			Title:    slideTitle,
 			Words:    wordCount,

--- a/core/query.go
+++ b/core/query.go
@@ -1,12 +1,21 @@
 package core
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 )
+
+// ErrAmbiguousSlideRef is returned by ResolveSlide when a reference matches
+// more than one slide. The error message names the candidate filenames so
+// callers can pick a specific one.
+//
+// Callers should use errors.Is(err, ErrAmbiguousSlideRef) to check for this
+// condition rather than string matching.
+var ErrAmbiguousSlideRef = errors.New("slide reference is ambiguous")
 
 // QueryOpts holds the options for a CSS selector query operation on a slide.
 type QueryOpts struct {
@@ -40,14 +49,28 @@ type BatchOperation struct {
 	All      bool   `json:"all,omitempty"`
 }
 
-// ResolveSlide resolves a slide reference (1-based number or name substring)
-// to a filename from the deck's slide list.
+// ResolveSlide resolves a slide reference to a filename from the deck's
+// slide list. Reference forms are tried in this priority order:
+//
+//  1. Numeric — a 1-based position number ("2" → the second slide)
+//  2. Exact filename — "03-intro.html"
+//  3. Exact slug — "intro" matches "NN-intro.html" for exactly one slide
+//  4. Substring fallback — legacy behavior for partial filename matches
+//
+// Steps 3 and 4 check for ambiguity: if the reference matches more than one
+// slide, the function returns ErrAmbiguousSlideRef wrapped with the list of
+// candidate filenames, rather than silently picking the first match.
+//
+// TODO(#83): prepend a slide_id lookup branch above the slug match once
+// .slyds.yaml stores per-slide metadata. slide_id is rename-safe where slug
+// is not.
 func (d *Deck) ResolveSlide(ref string) (string, error) {
 	slides, err := d.SlideFilenames()
 	if err != nil {
 		return "", err
 	}
 
+	// 1. Numeric: 1-based position
 	if num, err := strconv.Atoi(ref); err == nil {
 		if num < 1 || num > len(slides) {
 			return "", fmt.Errorf("slide %d out of range (have %d slides)", num, len(slides))
@@ -55,11 +78,42 @@ func (d *Deck) ResolveSlide(ref string) (string, error) {
 		return slides[num-1], nil
 	}
 
+	// 2. Exact filename match
 	for _, s := range slides {
-		if strings.Contains(s, ref) {
+		if s == ref {
 			return s, nil
 		}
 	}
+
+	// 3. Exact slug match (slug = filename without NN- prefix and .html suffix)
+	var slugMatches []string
+	for _, s := range slides {
+		slug := strings.TrimSuffix(ExtractNamePart(s), ".html")
+		if slug == ref {
+			slugMatches = append(slugMatches, s)
+		}
+	}
+	if len(slugMatches) == 1 {
+		return slugMatches[0], nil
+	}
+	if len(slugMatches) > 1 {
+		return "", fmt.Errorf("%w: slug %q matches %v", ErrAmbiguousSlideRef, ref, slugMatches)
+	}
+
+	// 4. Substring fallback (legacy behavior, now ambiguity-checked)
+	var subMatches []string
+	for _, s := range slides {
+		if strings.Contains(s, ref) {
+			subMatches = append(subMatches, s)
+		}
+	}
+	if len(subMatches) == 1 {
+		return subMatches[0], nil
+	}
+	if len(subMatches) > 1 {
+		return "", fmt.Errorf("%w: %q matches %v", ErrAmbiguousSlideRef, ref, subMatches)
+	}
+
 	return "", fmt.Errorf("slide %q not found", ref)
 }
 

--- a/core/scaffold.go
+++ b/core/scaffold.go
@@ -112,9 +112,13 @@ func generateSlidesFromThemeFS(fsys templar.WritableFS, readTmpl func(string) ([
 	}
 	files = append(files, name)
 
-	// Content slides
+	// Content slides — unique slugs per slide (see generateSlidesFS comment).
 	for i := 2; i < count; i++ {
-		name = fmt.Sprintf("%02d-slide.html", i)
+		slug := "slide"
+		if i > 2 {
+			slug = fmt.Sprintf("slide-%d", i-1)
+		}
+		name = fmt.Sprintf("%02d-%s.html", i, slug)
 		if err := render("slides/content.html.tmpl", map[string]any{"Title": title, "Number": i}, name); err != nil {
 			return nil, fmt.Errorf("content slide %d: %w", i, err)
 		}

--- a/core/scaffold_fs.go
+++ b/core/scaffold_fs.go
@@ -167,9 +167,16 @@ func generateSlidesFS(fsys templar.WritableFS, theme, title string, count int) (
 	fsys.WriteFile("slides/"+name, []byte(content), 0644)
 	files = append(files, name)
 
-	// Content slides
+	// Content slides — each placeholder gets a unique slug so slug-based
+	// references are unambiguous from day one. The first content slide
+	// keeps the bare "slide" slug; subsequent ones follow the same -N
+	// suffix convention SlugifySlides and InsertSlide use.
 	for i := 2; i < count; i++ {
-		name = fmt.Sprintf("%02d-slide.html", i)
+		slug := "slide"
+		if i > 2 {
+			slug = fmt.Sprintf("slide-%d", i-1)
+		}
+		name = fmt.Sprintf("%02d-%s.html", i, slug)
 		data = map[string]any{"Title": fmt.Sprintf("Slide %d", i), "Number": i}
 		content, err = Render("content", data)
 		if err != nil {

--- a/core/scaffold_test.go
+++ b/core/scaffold_test.go
@@ -391,3 +391,57 @@ func TestCreateHasThemesDirectory(t *testing.T) {
 		}
 	}
 }
+
+// TestCreate_ThreeSlideDeckFilenamesUnchanged is a regression guard: the
+// 3-slide scaffolding path must still produce exactly
+// 01-title.html, 02-slide.html, 03-closing.html (the pre-#78 layout).
+// The slug uniqueness fix only kicks in for decks with >= 4 slides.
+func TestCreate_ThreeSlideDeckFilenamesUnchanged(t *testing.T) {
+	_, mfs := scaffoldMem(t, "Three Slides", withSlides(3))
+	for _, f := range []string{
+		"slides/01-title.html",
+		"slides/02-slide.html",
+		"slides/03-closing.html",
+	} {
+		if !hasFile(mfs, f) {
+			t.Errorf("missing file: %s", f)
+		}
+	}
+}
+
+// TestCreate_LargeDeckHasUniqueSlugs verifies that scaffolding a deck with
+// 5 slides produces 5 unique slugs — the whole point of the scaffolder fix
+// in #78. Before the fix, slides 2–4 all shared the slug "slide". This
+// test directly asserts that every slug appears exactly once.
+func TestCreate_LargeDeckHasUniqueSlugs(t *testing.T) {
+	d, mfs := scaffoldMem(t, "Large Deck", withSlides(5))
+
+	expected := []string{
+		"slides/01-title.html",
+		"slides/02-slide.html",
+		"slides/03-slide-2.html",
+		"slides/04-slide-3.html",
+		"slides/05-closing.html",
+	}
+	for _, f := range expected {
+		if !hasFile(mfs, f) {
+			t.Errorf("missing file: %s", f)
+		}
+	}
+
+	// And the slugs in the Describe() output are all unique.
+	desc, err := d.Describe()
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, s := range desc.Slides {
+		if seen[s.Slug] {
+			t.Errorf("duplicate slug %q in scaffolded deck", s.Slug)
+		}
+		seen[s.Slug] = true
+	}
+	if len(seen) != 5 {
+		t.Errorf("got %d unique slugs, want 5", len(seen))
+	}
+}

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -55,11 +55,11 @@ Agents call tools to create, read, modify, and build decks. Each tool takes a `d
 | `list_decks` | — | List all decks with name, title, theme, slide count |
 | `create_deck` | `name`, `title`, `theme?`, `slides?` | Scaffold a new presentation |
 | `describe_deck` | `deck` | Deck metadata: title, theme, slide list with layouts and word counts |
-| `list_slides` | `deck` | Slide filenames, layouts, titles, word counts |
-| `read_slide` | `deck`, `position` | Raw HTML content of a slide (1-based) |
-| `edit_slide` | `deck`, `position`, `content` | Replace a slide's HTML content |
-| `query_slide` | `deck`, `slide`, `selector`, ... | CSS selector read/write (goquery) — text, HTML, attrs, mutations |
-| `add_slide` | `deck`, `position`, `name`, `layout?`, `title?` | Insert slide at position using layout template |
+| `list_slides` | `deck` | Slide filenames, slugs, layouts, titles, word counts |
+| `read_slide` | `deck`, `slide` or `position` | Raw HTML content of a slide. `slide` (preferred) accepts slug, filename, or position as string. |
+| `edit_slide` | `deck`, `slide` or `position`, `content` | Replace a slide's HTML content. `slide` is stable across inserts; `position` is legacy. |
+| `query_slide` | `deck`, `slide`, `selector`, ... | CSS selector read/write (goquery) — `slide` accepts slug, filename, or position |
+| `add_slide` | `deck`, `position`, `name`, `layout?`, `title?` | Insert slide at position using layout template. Slug auto-suffixes on collision (`intro` → `intro-2`). |
 | `remove_slide` | `deck`, `slide` | Remove slide by filename or position |
 | `check_deck` | `deck` | Validate deck: missing files, broken includes, missing notes |
 | `build_deck` | `deck` | Build self-contained HTML (resolves includes, inlines CSS/JS/images) |
@@ -106,6 +106,24 @@ slyds mcp [flags]
 | **Streamable HTTP** | (default) | 6274 | Any HTTP client, remote agents |
 | **SSE** | `--sse` | 6274 | Legacy SSE clients |
 | **stdio** | `--stdio` | — | Local editors (Cursor, Claude Desktop, VS Code) |
+
+## Slide Identity
+
+Slides have three overlapping identifiers in the MCP API:
+
+| Reference | Stable across... | Use when |
+|-----------|-----------------|----------|
+| **Position** (`2`) | same session only | legacy/simple access |
+| **Filename** (`02-metrics.html`) | content edits | you already have it from a previous response |
+| **Slug** (`metrics`) | inserts, removes, moves | you want to re-reference the slide after structural changes |
+
+Agents should prefer **slug** for references that survive insert/remove operations. The `slide` parameter on `read_slide`, `edit_slide`, `query_slide`, and `remove_slide` accepts any of the three forms — the server tries numeric → exact filename → exact slug → substring match.
+
+**Slug uniqueness** is enforced within a deck. `add_slide` auto-suffixes colliding slugs with `-2`, `-3`, ... (e.g. inserting a second slide named `intro` produces `intro-2`). The `add_slide` response text reports the final slug when auto-suffixing occurs.
+
+**Ambiguous references** return a clear error instead of silently picking the first match. If a substring or slug matches more than one slide, the response lists the candidates so the agent can retry with a specific filename.
+
+Slug is **not rename-safe**: `slyds slides slugify` changes slugs based on `<h1>` headings. A truly rename-safe `slide_id` (stored in `.slyds.yaml`) is planned for a follow-up PR.
 
 ## Server Configuration (mcpkit v0.1.15)
 


### PR DESCRIPTION
## Summary

Make slug (the non-prefix portion of `NN-slug.html`) the stable handle for slide references in the MCP API. Enforce slug uniqueness at every creation path so slug-based references are unambiguous in both scaffolded and agent-authored decks. This is PR 2 of 4 for issue #74 (Workspace abstraction line) and the prerequisite for #83 (persistent slide IDs) → #79 (optimistic versioning).

**Zero breaking changes for MCP clients using `position`.** New `slide` parameter on `read_slide` / `edit_slide` is strictly additive and backward compatible.

## Why now

`#74` PR 1 landed the Workspace abstraction in v0.1.3. The next step in making MCP mutations robust to concurrent agents is giving each slide a stable reference that survives structural mutations (inserts, removes, moves). Position is useless for this — it shifts on every insert. Filename is useless — the numeric prefix renumbers. Slug is the only identifier that `RewriteSlideOrder` already preserves across renumbering, and this PR makes it a first-class citizen in the API.

## Design

### Core changes

**`core.SlideDescription.Slug`** — new field, populated from filename via `ExtractNamePart` + strip `.html`. Purely additive — existing consumers ignore it, new ones consume it for stable references.

**`core.Deck.ResolveSlide`** rewritten with a priority chain:

1. Numeric → 1-based position
2. Exact filename match → `03-intro.html`
3. Exact slug match → `intro` matches `NN-intro.html`
4. Substring fallback (legacy) → `strings.Contains`
5. No match → error

Ambiguity is now **detected** at every step — if a slug or substring matches more than one slide, the function returns a new `ErrAmbiguousSlideRef` with the list of candidate filenames instead of silently picking the first one. This is a strict improvement: the previous silent behavior was already wrong.

**`core.Deck.InsertSlide`** signature: `error` → `(string, error)`. Returns the final slug actually used, which may differ from the requested name if auto-suffixing was applied. New `uniqueSlug` helper implements the `-2`, `-3`, `-4`, ... pattern to match `SlugifySlides`.

**Scaffolder fix** (`core/scaffold_fs.go`, `core/scaffold.go`): `slyds init --slides 5` previously produced three slides with the same slug `slide` (`01-title`, `02-slide`, `03-slide`, `04-slide`, `05-closing`). Now produces `01-title`, `02-slide`, `03-slide-2`, `04-slide-3`, `05-closing` — all unique. **3-slide scaffolding is unchanged** (regression guard test added).

### MCP tool changes

**`read_slide` / `edit_slide`** accept a new `slide` string parameter (slug, filename, or position as string) alongside the existing `position` int. `slide` takes precedence if both are provided. Agents migrate at their own pace. Request shape:

```json
{"deck": "q3", "slide": "metrics", "content": "..."}
```

**`add_slide`** response text reports the actual slug when auto-suffix kicks in:

```
Slide "intro" inserted at position 3 (slug auto-suffixed to "intro-2" to avoid collision).
```

**`query_slide` / `remove_slide`** need no changes — they already take a `slide` string parameter, which now benefits from the new priority-chain `ResolveSlide`.

## Files

| File | Change |
|------|--------|
| `core/deck.go` | `uniqueSlug` helper, `InsertSlide` signature → `(string, error)` |
| `core/describe.go` | `SlideDescription.Slug` field, populated in `Describe()` |
| `core/query.go` | `ResolveSlide` priority chain + `ErrAmbiguousSlideRef` |
| `core/scaffold.go`, `core/scaffold_fs.go` | Unique slugs for content slides |
| `cmd/mcp_tools.go` | `read_slide` / `edit_slide` accept `slide` string, `add_slide` reports final slug, new `resolveSlidePosition` helper |
| `cmd/slides.go` | CLI `add`/`insert` capture new return value, stderr note on collision |
| `cmd/slides_test.go`, `core/deck_test.go` | Existing callers updated to new `InsertSlide` signature |
| `core/deck_test.go` | 11 new slug tests |
| `core/scaffold_test.go` | 2 new scaffolder tests (3-slide regression + 5-slide unique slugs) |
| `cmd/mcp_tools_test.go` | 4 new MCP tool tests |
| `cmd/mcp_e2e_test.go` | `TestE2E_SlugRefSurvivesInsert` — canonical integration test |
| Docs | `CLAUDE.md`, `ARCHITECTURE.md` (new "Slide identity" subsection), `README.md`, `ROADMAP.md` (Phase 9i), `NEXTSTEPS.md`, `docs/MCP.md` (new "Slide Identity" section) |

## Test plan

- [x] Red-before-green: 17 new tests all pass after implementation
- [x] `TestE2E_SlugRefSurvivesInsert` — the canonical test proving the whole PR's motivation. Creates a 5-slide deck, edits by slug, inserts a new slide earlier (shifting positions), edits by same slug again, reads by slug — all three slug references land on the same original file despite the position shift.
- [x] `TestResolveSlide_BySlugAmbiguous` / `BySubstringAmbiguous` — ambiguity is detected, candidates are reported
- [x] `TestInsertSlide_SlugCollisionAutoSuffix` / `MultipleSuffix` — auto-suffix walks past existing `-N` slugs
- [x] `TestCreate_LargeDeckHasUniqueSlugs` — scaffolder fix verified (5-slide deck has 5 unique slugs)
- [x] `TestCreate_ThreeSlideDeckFilenamesUnchanged` — 3-slide scaffolding regression guard
- [x] `TestDescribe_IncludesSlug` — Slug field populated
- [x] `TestReadSlideTool_BySlideParam` / `TestEditSlideTool_BySlideParam` — MCP tool `slide` param end-to-end
- [x] `TestEditSlideTool_RequiresPositionOrSlide` — validation error when neither is set
- [x] `TestAddSlideTool_SlugCollision` — auto-suffix visible in MCP response
- [x] All existing tests unchanged and passing — full `go test ./...` suite green
- [x] `make test` + pre-push hook green
- [x] Smoke test: `slyds init -n 5` produces 5 unique slugs; `slyds describe --json` includes slug field
- [x] Constraint check: no new regex HTML mutation (only pre-existing legacy regex in check.go/describe.go/layout.go/slides.go)

### Assertion audit

- **Added**: 17 new test functions, ~60 assertions
- **Removed**: 0
- **Weakened**: 0
- **Modified**: 5 existing tests updated to new `InsertSlide` signature (captured second return value as `_`), assertions unchanged

## Behavior changes visible to agents

- **`describe_deck`, `list_slides`, `read_slide` resources**: now include a `slug` field per slide (additive)
- **`add_slide` response**: mentions auto-suffixed slug when collision occurs
- **`read_slide` / `edit_slide`**: new optional `slide` string parameter
- **`ResolveSlide`**: ambiguous substring matches now return an error instead of silently picking the first match. **This is the only behavior change that could affect existing agents**, and only if they were relying on the silently-wrong first-match behavior. The fix is to pass an unambiguous reference (exact slug, full filename, or position).

## Non-goals (tracked separately)

| Follow-up | Issue |
|-----------|-------|
| Persistent slide IDs in `.slyds.yaml` for rename-safe identity | #83 (new, next subtask) |
| Optimistic versioning on MCP mutations (locks on slide_id) | #79 |
| Multi-root workspace.yaml config | #80 |
| previewCache tenant scoping | #81 |
| Hosted MCP service | #76 |

`TODO(#83)` comments are left in `core/deck.go`, `core/describe.go`, and `core/query.go` at the exact spots where slide_id will plug in — purely additive, no undo needed.

## Dependency chain

```
#74 Workspace abstraction (PR 1) — v0.1.3 ✓
  └─ #78 Slug-as-ID (this PR) ✓
       └─ #83 Persistent slide IDs (next)
            └─ #79 Optimistic versioning
                 └─ #76 Hosted MCP
```

Closes part of #74 (PR 2 of 4). Closes #78.