### PR TITLE
feat: persistent slide IDs in .slyds.yaml (#83)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,11 +142,21 @@ The `slyds ws` CLI subcommand exercises the same `LocalWorkspace` implementation
 
 ### Slide identity
 
-Slides have three overlapping identifiers: **position** (1-based, changes on insert/remove), **filename** (`NN-slug.html`, prefix changes on renumber), and **slug** (the non-prefix portion of the filename, stable across inserts/removes/moves because `RewriteSlideOrder` preserves it). Agents should prefer slug for references that survive position shifts.
+Slides have three overlapping identifiers, each stable across a different set of mutations:
 
-Slug uniqueness within a deck is enforced at every creation path — `InsertSlide` auto-suffixes on collision (`intro`, `intro-2`, `intro-3`), and the scaffolder produces unique slugs by default even for large decks (`01-title.html`, `02-slide.html`, `03-slide-2.html`, `04-slide-3.html`, `05-closing.html`). `ResolveSlide` accepts slug, filename, or position as a reference and returns `ErrAmbiguousSlideRef` if a reference matches more than one slide instead of silently picking the first match.
+| Reference | Format | Stable across inserts? | Stable across renames? |
+|-----------|--------|----------------------|----------------------|
+| **Position** | `2` | No | Yes |
+| **Slug** | `metrics` | Yes | No |
+| **Slide ID** | `sl_a1b2c3d4` | Yes | Yes |
 
-Slug is the best "stable handle" the current file-based backend provides, but it is not truly rename-safe — running `slyds slides slugify` can change a slide's slug. A rename-safe `slide_id` stored in `.slyds.yaml` is planned as the next subtask of #74 (#83) so optimistic versioning (#79) can lock on an identifier that survives both position shifts and renames.
+**Slug** is the non-prefix portion of `NN-slug.html`. Uniqueness is enforced at every creation path — `InsertSlide` auto-suffixes on collision (`intro` → `intro-2`), and the scaffolder produces unique slugs. `ResolveSlide` accepts slug, filename, or position and returns `ErrAmbiguousSlideRef` on multi-match.
+
+**Slide ID** (`sl_` + 8 hex chars) is an opaque identifier assigned by slyds on slide creation and stored in `.slyds.yaml` as per-slide `{id, file}` records. The ID never changes; only the `file` value updates when a slide is renamed or renumbered. `ResolveSlide` checks slide_id as its highest-priority match (before numeric, filename, slug, and substring).
+
+Mutation methods (`AddSlide`, `InsertSlide`, `RemoveSlide`, `MoveSlide`, `SlugifySlides`, `RewriteSlideOrder`) maintain the id→file mapping atomically: `ensureSlideIDs()` is called before the mutation (auto-migrating legacy decks without IDs), and `saveManifest()` is called after. Read-only operations (`Describe`, `list_slides`) do not trigger auto-migration — legacy decks return empty `slide_id` until their first mutation.
+
+The `DeckManifest` type has been eliminated; `Deck.Manifest` is now the full `*Manifest` type from `core/manifest.go`. The unexported `writeManifestFS` in `scaffold_fs.go` now delegates to the exported `WriteManifestFS` (`yaml.Marshal` path) ensuring all manifest fields are serialized correctly.
 
 **Model Context Protocol** (`cmd/mcp.go`, `cmd/mcp_tools.go`, `cmd/mcp_resources.go`, `cmd/mcp_apps.go`): uses **mcpkit** v0.1.15 (split packages: `core/`, `server/`) + **ext/ui** v0.1.15 (MCP Apps). Single-struct registration (`srv.Register`), workspace middleware, per-tool timeouts, `StructuredResult` for typed output, error handler for session lifecycle, EventStore for Streamable HTTP reconnection. Exposes **13 tools** (11 core + 2 preview) and **7 browsable resources** for reading deck content. Transports: Streamable HTTP (default), SSE (`--sse`), or stdio (`--stdio`). `--deck-root` sets the local workspace root. See [docs/MCP.md](docs/MCP.md).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ All Deck I/O goes through `templar.WritableFS` (v0.1.0). No `os.*`/`filepath.*` 
 
 - **Deck is the single API** — cmd/ calls Deck methods, never touches FS internals
 - **Workspace is the MCP boundary** — MCP tool and resource handlers resolve decks via `workspaceFromContext(ctx).OpenDeck(name)`, never from raw paths. The workspace is installed on every request via `workspaceMiddleware`. See [cmd/workspace.go](cmd/workspace.go).
-- **Slug is the stable slide handle** — agents should reference slides by slug (the non-prefix portion of `NN-slug.html`), not by position, for identity across inserts/removes. Slug uniqueness is enforced at creation time via auto-suffixing (`intro`, `intro-2`, `intro-3`). `ResolveSlide` returns `ErrAmbiguousSlideRef` when a reference is ambiguous. Not rename-safe — a truly stable `slide_id` is planned in #83.
+- **Three-layer slide identity** — slides have position (mutable on insert), slug (stable across inserts, not across renames), and `slide_id` (stable across everything including renames). `slide_id` is a `sl_`-prefixed opaque ID stored per-slide in `.slyds.yaml` and returned by `describe_deck`/`list_slides`. Agents should use slug for human-readable references and slide_id for rename-safe caching. `ResolveSlide` accepts all three forms plus filenames/substrings.
 - **No hardcoded HTML** — use embedded `.tmpl` files under `assets/templates/`
 - **No regex HTML mutation** — use `d.Query()` (goquery/CSS selectors). See [CONSTRAINTS.md](CONSTRAINTS.md)
 - **Index.html is source of truth** for slide ordering

--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -44,7 +44,7 @@
 - [x] ~~mcpkit v0.1.15 adoption — single-struct registration, per-tool timeouts, StructuredResult, error handler, EventStore (#71)~~
 - [x] ~~Workspace abstraction — `cmd/workspace.go`, `slyds ws` CLI, MCP middleware-based deck resolution (#74, PR 1 of 4)~~
 - [x] ~~Slug-as-ID in MCP tools + slug uniqueness — `Slug` field, priority-chain `ResolveSlide`, scaffolder fix, `slide` param on read/edit (#78, #74 PR 2 of 4)~~
-- [ ] Persistent slide IDs in `.slyds.yaml` for rename-safe identity (#83, next subtask)
+- [x] ~~Persistent slide IDs in `.slyds.yaml` — rename-safe `sl_` IDs stored per-slide in manifest, auto-migrated, ResolveSlide priority-0 branch (#83)~~
 - [ ] Optimistic versioning on MCP mutations (#79, locks on slide_id)
 - [ ] Multi-root workspace.yaml config (#80)
 - [ ] Slide folders with co-located assets (e.g., `slides/03-architecture/slide.html` + `diagram.png`)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,9 @@ Introduced a `Workspace` interface (`cmd/workspace.go`) to decouple MCP tool and
 ## Phase 9i — Slug-as-ID in MCP tools (done)
 Made slug (the non-prefix portion of `NN-slug.html`) the stable handle for slide references in the MCP API. `SlideDescription` grew a `Slug` field returned by `describe_deck` / `list_slides`. `ResolveSlide` rewritten with a priority chain (numeric → exact filename → exact slug → substring fallback) and new `ErrAmbiguousSlideRef` for multi-match cases. `InsertSlide` auto-suffixes colliding slugs via the same `-N` pattern `SlugifySlides` already uses, and now returns `(finalSlug, error)` so callers can surface the actual name. Scaffolder fixed so `slyds init --slides 5` produces unique slugs by default (`slide`, `slide-2`, `slide-3`). MCP `read_slide` and `edit_slide` accept a new `slide` string parameter (slug, filename, or position) alongside the existing `position` int for backward compat. `TestE2E_SlugRefSurvivesInsert` is the canonical integration test proving slug stability across position shifts.
 
+## Phase 9j — Persistent slide IDs (done)
+Added a rename-safe `slide_id` per slide, stored as `slides: [{id, file}]` records in `.slyds.yaml`. IDs are `sl_` + 8 hex chars, generated at slide creation time via `crypto/rand`, and survive every mutation including inserts, removes, moves, and slugify renames. `Deck.Manifest` unified from the minimal `DeckManifest` to the full `Manifest` type. `writeManifestFS` unified from a hand-formatted string to the exported `yaml.Marshal` path. `ResolveSlide` gains a priority-0 branch for `sl_`-prefixed references. `SlideDescription` gains a `SlideID` field populated by `Describe()`. Legacy decks auto-migrate on first mutation. Scaffolder assigns IDs at creation time. Canonical test: `TestE2E_SlideIDSurvivesRename`.
+
 ## Phase 10 — Slide Folders
 Support `slides/03-name/slide.html` with co-located assets (images, per-slide CSS). Auto-detect folder vs file slides.
 

--- a/cmd/mcp_e2e_test.go
+++ b/cmd/mcp_e2e_test.go
@@ -355,6 +355,73 @@ func TestPerToolTimeout(t *testing.T) {
 	}
 }
 
+// TestE2E_SlideIDSurvivesRename is the canonical integration test for
+// slide_id (#83): it proves that a slide_id reference survives a rename
+// (slugify) that changes the slide's slug and filename — the exact
+// scenario that slug alone cannot handle.
+//
+// Flow:
+//  1. Scaffold a 3-slide deck (IDs assigned at scaffold time).
+//  2. Describe the deck; capture slide 2's slide_id.
+//  3. Edit slide 2's content to change its <h1> heading.
+//  4. Call SlugifySlides (via the CLI path) to rename slides based on
+//     headings — slide 2's slug changes.
+//  5. Read the slide by its ORIGINAL slide_id — should resolve to the
+//     renamed file and return the new content.
+func TestE2E_SlideIDSurvivesRename(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("ID Rename Test", 3, "default", fmt.Sprintf("%s/test-deck", root), true)
+
+	c := newSlydsMCPClient(t, root)
+
+	// 1. Get slide 2's slide_id from describe_deck
+	descResult := c.ToolCall("describe_deck", map[string]any{"deck": "test-deck"})
+	type slideInfo struct {
+		SlideID string `json:"slide_id"`
+		Slug    string `json:"slug"`
+	}
+	type deckDesc struct {
+		Slides []slideInfo `json:"slides"`
+	}
+	var desc deckDesc
+	json.Unmarshal([]byte(descResult), &desc)
+	if len(desc.Slides) < 2 {
+		t.Fatalf("expected >=2 slides, got %d", len(desc.Slides))
+	}
+	slideID := desc.Slides[1].SlideID
+	if slideID == "" {
+		t.Fatal("slide 2 has no slide_id")
+	}
+
+	// 2. Edit slide 2's content to give it a distinctive heading
+	newContent := `<div class="slide" data-layout="content"><h1>Renamed Heading</h1><p>marker-rename</p></div>`
+	c.ToolCall("edit_slide", map[string]any{
+		"deck": "test-deck", "slide": slideID, "content": newContent,
+	})
+
+	// 3. Run slugify to rename slides based on headings — this changes
+	//    slide 2's slug and filename.
+	d, _ := core.OpenDeckDir(fmt.Sprintf("%s/test-deck", root))
+	renamed, err := d.SlugifySlides(core.Slugify)
+	if err != nil {
+		t.Fatalf("SlugifySlides: %v", err)
+	}
+	if renamed == 0 {
+		t.Fatal("slugify should have renamed at least 1 slide")
+	}
+
+	// 4. Reconnect — the deck state changed on disk outside MCP
+	c2 := newSlydsMCPClient(t, root)
+
+	// 5. Read the slide by its ORIGINAL slide_id — should still work!
+	readResult := c2.ToolCall("read_slide", map[string]any{
+		"deck": "test-deck", "slide": slideID,
+	})
+	if !strings.Contains(readResult, "marker-rename") {
+		t.Errorf("read by slide_id after rename didn't return the edited content: %s", readResult[:min(200, len(readResult))])
+	}
+}
+
 // TestE2E_SlugRefSurvivesInsert is the canonical integration test for
 // slug-as-ID (#78): it proves that a slug-based `slide` reference remains
 // stable across a structural mutation that shifts position numbers.

--- a/cmd/mcp_tools.go
+++ b/cmd/mcp_tools.go
@@ -403,18 +403,21 @@ func addSlideTool() server.Tool {
 			if errResult != nil {
 				return *errResult, nil
 			}
-			finalSlug, err := d.InsertSlide(p.Position, p.Name, p.Layout, p.Title)
+			finalSlug, slideID, err := d.InsertSlide(p.Position, p.Name, p.Layout, p.Title)
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
 			}
 			mcpcore.NotifyResourcesChanged(ctx)
 			if finalSlug != p.Name {
 				return mcpcore.TextResult(fmt.Sprintf(
-					"Slide %q inserted at position %d (slug auto-suffixed to %q to avoid collision).",
-					p.Name, p.Position, finalSlug,
+					"Slide %q inserted at position %d (slug auto-suffixed to %q to avoid collision, slide_id: %q).",
+					p.Name, p.Position, finalSlug, slideID,
 				)), nil
 			}
-			return mcpcore.TextResult(fmt.Sprintf("Slide %q inserted at position %d.", p.Name, p.Position)), nil
+			return mcpcore.TextResult(fmt.Sprintf(
+				"Slide %q inserted at position %d (slide_id: %q).",
+				p.Name, p.Position, slideID,
+			)), nil
 		},
 	}
 }

--- a/cmd/slides.go
+++ b/cmd/slides.go
@@ -52,7 +52,7 @@ var addCmd = &cobra.Command{
 		}
 
 		layoutName := resolveLayoutFlag(slideLayout, slideType)
-		finalName, err := d.InsertSlide(position, name, layoutName, "")
+		finalName, _, err := d.InsertSlide(position, name, layoutName, "")
 		if err != nil {
 			return err
 		}
@@ -231,7 +231,7 @@ after insertion to maintain consistent NN-name.html naming.`,
 		}
 
 		layoutName := resolveLayoutFlag(insertLayout, insertType)
-		finalName, err := d.InsertSlide(pos, name, layoutName, insertTitle)
+		finalName, _, err := d.InsertSlide(pos, name, layoutName, insertTitle)
 		if err != nil {
 			return err
 		}

--- a/cmd/slides_test.go
+++ b/cmd/slides_test.go
@@ -17,7 +17,7 @@ func runInsert(root string, pos int, name, layoutName, title string) error {
 	if err != nil {
 		return err
 	}
-	_, err = d.InsertSlide(pos, name, layoutName, title)
+	_, _, err = d.InsertSlide(pos, name, layoutName, title)
 	return err
 }
 

--- a/core/deck.go
+++ b/core/deck.go
@@ -18,30 +18,45 @@ import (
 
 var includeRe = regexp.MustCompile(`\{\{#\s*include\s+"(slides/[^"]+)"\s*#\}\}`)
 
-// DeckManifest holds the parsed .slyds.yaml configuration.
-type DeckManifest struct {
-	Theme string `yaml:"theme" json:"theme"`
-	Title string `yaml:"title" json:"title"`
-}
-
 // Deck represents an opened slyds presentation deck.
 // All I/O goes through the FS field (templar.WritableFS), making it portable.
+//
+// Deck is NOT safe for concurrent use. Mutation methods assume a single
+// caller at a time; hosted multi-tenant deployments (#76) will need a
+// concurrency layer above this.
 type Deck struct {
 	// FS is the writable filesystem backing this deck.
 	FS templar.WritableFS
 
-	// Manifest is the parsed .slyds.yaml configuration. May be nil if none exists.
-	Manifest *DeckManifest
+	// Manifest is the parsed .slyds.yaml configuration. May be nil if
+	// none exists on disk yet. Mutation methods that touch the slide set
+	// populate and persist it on demand.
+	Manifest *Manifest
+
+	// Derived id→file and file→id indices, rebuilt from Manifest.Slides
+	// on OpenDeck and after every mutation. Not persisted, not exported:
+	// ResolveSlide and the mutation methods use them for O(1) lookups
+	// instead of linearly scanning Manifest.Slides on every call. See
+	// rebuildIndices and ensureSlideIDs in slide_ids.go.
+	idByFile map[string]string
+	fileByID map[string]string
 }
 
 // OpenDeck opens an existing deck from the given filesystem.
 // The FS root should be the deck directory (containing index.html).
+//
+// The manifest's Slides records (if any) are loaded into derived
+// id→file indices for O(1) lookup. Read-only operations do NOT
+// auto-migrate legacy decks — that only happens on the first mutation
+// via ensureSlideIDs.
 func OpenDeck(fsys templar.WritableFS) (*Deck, error) {
 	if _, err := fsys.ReadFile("index.html"); err != nil {
 		return nil, fmt.Errorf("no index.html found — is this a slyds presentation?")
 	}
 	manifest := readManifest(fsys)
-	return &Deck{FS: fsys, Manifest: manifest}, nil
+	d := &Deck{FS: fsys, Manifest: manifest}
+	d.rebuildIndices()
+	return d, nil
 }
 
 // Title returns the deck's title from the manifest, or "" if unknown.
@@ -121,15 +136,19 @@ func (d *Deck) EditSlideContent(position int, content string) error {
 
 // RewriteSlideOrder renumbers slide files and rebuilds index.html to match
 // the given ordering. Files are renamed via temp names to avoid collisions.
+// After the rename pass, the slide_id mapping in the manifest is updated
+// to reflect the new filenames and persisted to .slyds.yaml.
 func (d *Deck) RewriteSlideOrder(orderedFiles []string) error {
 	type renamePair struct{ from, to string }
 	var renames []renamePair
+	renameMap := make(map[string]string) // oldName → newName
 
 	for i, oldName := range orderedFiles {
 		namePart := ExtractNamePart(oldName)
 		newName := fmt.Sprintf("%02d-%s", i+1, namePart)
 		if oldName != newName {
 			renames = append(renames, renamePair{oldName, newName})
+			renameMap[oldName] = newName
 		}
 		orderedFiles[i] = newName
 	}
@@ -141,7 +160,7 @@ func (d *Deck) RewriteSlideOrder(orderedFiles []string) error {
 		d.FS.Rename("slides/"+r.from+".tmp", "slides/"+r.to)
 	}
 
-	indexData, err := d.FS.ReadFile( "index.html")
+	indexData, err := d.FS.ReadFile("index.html")
 	if err != nil {
 		return err
 	}
@@ -163,12 +182,25 @@ func (d *Deck) RewriteSlideOrder(orderedFiles []string) error {
 		newLines = append(newLines, line)
 	}
 
-	return d.FS.WriteFile("index.html", []byte(strings.Join(newLines, "\n")), 0644)
+	if err := d.FS.WriteFile("index.html", []byte(strings.Join(newLines, "\n")), 0644); err != nil {
+		return err
+	}
+
+	// Update slide_id mapping for any renamed files and persist.
+	if len(renameMap) > 0 && d.Manifest != nil && len(d.Manifest.Slides) > 0 {
+		d.updateSlideFilenames(renameMap)
+		return d.saveManifest()
+	}
+	return nil
 }
 
 // AddSlide creates a new slide file at the given position with the given content,
-// inserts it into the ordering, and renumbers all slides.
+// inserts it into the ordering, assigns a slide_id, and renumbers all slides.
 func (d *Deck) AddSlide(position int, filename string, content string) error {
+	if err := d.ensureSlideIDs(); err != nil {
+		return err
+	}
+
 	existing, err := d.SlideFilenames()
 	if err != nil {
 		return err
@@ -182,6 +214,15 @@ func (d *Deck) AddSlide(position int, filename string, content string) error {
 		return err
 	}
 
+	// Assign a slide_id to the new file before RewriteSlideOrder renames it.
+	usedIDs := make(map[string]bool, len(d.Manifest.Slides))
+	for _, rec := range d.Manifest.Slides {
+		usedIDs[rec.ID] = true
+	}
+	newID := uniqueSlideID(usedIDs)
+	d.Manifest.Slides = append(d.Manifest.Slides, SlideRecord{ID: newID, File: filename})
+	d.rebuildIndices()
+
 	newOrder := make([]string, 0, len(existing)+1)
 	newOrder = append(newOrder, existing[:position-1]...)
 	newOrder = append(newOrder, filename)
@@ -190,8 +231,13 @@ func (d *Deck) AddSlide(position int, filename string, content string) error {
 	return d.RewriteSlideOrder(newOrder)
 }
 
-// RemoveSlide removes a slide by filename, renumbers remaining slides.
+// RemoveSlide removes a slide by filename, drops its slide_id record,
+// and renumbers remaining slides.
 func (d *Deck) RemoveSlide(filename string) error {
+	if err := d.ensureSlideIDs(); err != nil {
+		return err
+	}
+
 	existing, err := d.SlideFilenames()
 	if err != nil {
 		return err
@@ -199,6 +245,17 @@ func (d *Deck) RemoveSlide(filename string) error {
 	if err := d.FS.Remove("slides/" + filename); err != nil {
 		return err
 	}
+
+	// Remove the slide_id record for the deleted file.
+	kept := d.Manifest.Slides[:0]
+	for _, rec := range d.Manifest.Slides {
+		if rec.File != filename {
+			kept = append(kept, rec)
+		}
+	}
+	d.Manifest.Slides = kept
+	d.rebuildIndices()
+
 	var remaining []string
 	for _, f := range existing {
 		if f != filename {
@@ -209,7 +266,12 @@ func (d *Deck) RemoveSlide(filename string) error {
 }
 
 // MoveSlide reorders a slide from one position to another (1-based).
+// Slide IDs are preserved — only positions and filename prefixes change.
 func (d *Deck) MoveSlide(from, to int) error {
+	if err := d.ensureSlideIDs(); err != nil {
+		return err
+	}
+
 	existing, err := d.SlideFilenames()
 	if err != nil {
 		return err
@@ -231,8 +293,14 @@ func (d *Deck) MoveSlide(from, to int) error {
 
 // SlugifySlides renames slides based on their <h1> headings.
 // The slugFn parameter converts a heading string to a slug.
-// Returns the number of slides renamed.
+// Returns the number of slides renamed. Slide IDs are preserved
+// across the rename — the id→file mapping is updated to reflect
+// the new filenames.
 func (d *Deck) SlugifySlides(slugFn func(string) string) (int, error) {
+	if err := d.ensureSlideIDs(); err != nil {
+		return 0, err
+	}
+
 	slides, err := d.SlideFilenames()
 	if err != nil {
 		return 0, err
@@ -247,7 +315,7 @@ func (d *Deck) SlugifySlides(slugFn func(string) string) (int, error) {
 		heading := ExtractFirstHeading(content)
 		if heading == "" {
 			newNames[i] = filename
-			slug := strings.TrimSuffix(ExtractNamePart(filename), ".html")
+			slug := slideSlugFromFile(filename)
 			usedSlugs[slug]++
 			continue
 		}
@@ -269,13 +337,22 @@ func (d *Deck) SlugifySlides(slugFn func(string) string) (int, error) {
 		return 0, nil
 	}
 
+	// Build the rename map for the slug portion. RewriteSlideOrder will
+	// handle the numeric-prefix portion and update the manifest mapping.
+	slugRenames := make(map[string]string)
 	type renamePair struct{ from, to string }
 	var renames []renamePair
 	for i, oldName := range slides {
 		if newNames[i] != oldName {
 			renames = append(renames, renamePair{oldName, newNames[i]})
+			slugRenames[oldName] = newNames[i]
 		}
 	}
+
+	// Update the manifest mapping for slug changes BEFORE the filesystem
+	// rename, so RewriteSlideOrder sees the new filenames.
+	d.updateSlideFilenames(slugRenames)
+
 	for _, r := range renames {
 		d.FS.Rename("slides/"+r.from, "slides/"+r.from+".tmp")
 	}
@@ -283,7 +360,15 @@ func (d *Deck) SlugifySlides(slugFn func(string) string) (int, error) {
 		d.FS.Rename("slides/"+r.from+".tmp", "slides/"+r.to)
 	}
 
-	return renamed, d.RewriteSlideOrder(newNames)
+	if err := d.RewriteSlideOrder(newNames); err != nil {
+		return renamed, err
+	}
+	// RewriteSlideOrder only saves the manifest when it renames files
+	// (NN- prefix changes). After SlugifySlides' own rename pass, the
+	// prefixes are already correct, so RewriteSlideOrder skips the save.
+	// We must save explicitly here to persist the slug→file mapping
+	// changes that updateSlideFilenames applied in memory.
+	return renamed, d.saveManifest()
 }
 
 // InsertSlide renders a new slide from the named layout template and inserts
@@ -292,14 +377,13 @@ func (d *Deck) SlugifySlides(slugFn func(string) string) (int, error) {
 // auto-suffixed with -2, -3, ... (same convention as SlugifySlides) to keep
 // slugs unique within a deck.
 //
-// Returns the final slug actually used (may differ from the requested name
-// if auto-suffix was applied) and any error encountered.
+// Returns the final slug, the assigned slide_id, and any error. The
+// slide_id is the rename-safe handle for this slide — it survives every
+// future mutation including renames. Agents should prefer slide_id for
+// follow-up references when they plan to cache the identifier.
 //
 // Title overrides the display title (otherwise derived from the slug).
-//
-// TODO(#83): also return assigned slide_id once .slyds.yaml stores per-slide
-// metadata — gives callers a rename-safe handle separate from the slug.
-func (d *Deck) InsertSlide(position int, name, layoutName, title string) (string, error) {
+func (d *Deck) InsertSlide(position int, name, layoutName, title string) (string, string, error) {
 	finalName := d.uniqueSlug(name)
 
 	displayName := slugToTitle(finalName)
@@ -312,14 +396,25 @@ func (d *Deck) InsertSlide(position int, name, layoutName, title string) (string
 		"Number": position,
 	})
 	if err != nil {
-		return "", fmt.Errorf("layout %q: %w", layoutName, err)
+		return "", "", fmt.Errorf("layout %q: %w", layoutName, err)
 	}
 
 	filename := fmt.Sprintf("%02d-%s.html", position, finalName)
 	if err := d.AddSlide(position, filename, content); err != nil {
-		return "", err
+		return "", "", err
 	}
-	return finalName, nil
+
+	// After AddSlide, the file may have been renumbered. Look up the
+	// slide_id from the derived indices (AddSlide already assigned one
+	// and called RewriteSlideOrder which updated the mapping).
+	slideID := ""
+	for _, rec := range d.Manifest.Slides {
+		if slideSlugFromFile(rec.File) == finalName {
+			slideID = rec.ID
+			break
+		}
+	}
+	return finalName, slideID, nil
 }
 
 // uniqueSlug returns the desired slug if no existing slide uses it, otherwise
@@ -405,12 +500,15 @@ func (d *Deck) listSlideFiles() []string {
 	return files
 }
 
-func readManifest(fsys templar.WritableFS) *DeckManifest {
+// readManifest reads and parses .slyds.yaml into the full Manifest type.
+// Returns nil on any error (missing file, malformed yaml) — callers treat
+// a nil manifest as "legacy deck with no config" and degrade gracefully.
+func readManifest(fsys templar.WritableFS) *Manifest {
 	data, err := fsys.ReadFile(".slyds.yaml")
 	if err != nil {
 		return nil
 	}
-	var m DeckManifest
+	var m Manifest
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		return nil
 	}

--- a/core/deck_test.go
+++ b/core/deck_test.go
@@ -356,7 +356,7 @@ func TestInsertSlideWithLayout(t *testing.T) {
 	mfs.SetFile("slides/01-title.html", []byte(`<h1>Title</h1>`))
 
 	d, _ := OpenDeck(mfs)
-	if _, err := d.InsertSlide(2, "details", "content", ""); err != nil {
+	if _, _, err := d.InsertSlide(2, "details", "content", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -376,7 +376,7 @@ func TestInsertSlideWithTwoCol(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	_, _ = d.InsertSlide(2, "comparison", "two-col", "")
+	_, _, _ = d.InsertSlide(2, "comparison", "two-col", "")
 
 	content, _ := d.GetSlideContent(2)
 	if !strings.Contains(content, `data-layout="two-col"`) {
@@ -397,7 +397,7 @@ func TestInsertSlideWithTitle(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	_, _ = d.InsertSlide(1, "intro", "title", "Welcome Everyone")
+	_, _, _ = d.InsertSlide(1, "intro", "title", "Welcome Everyone")
 
 	content, _ := d.GetSlideContent(1)
 	if !strings.Contains(content, "Welcome Everyone") {
@@ -415,7 +415,7 @@ func TestInsertSlideUnknownLayout(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	_, err := d.InsertSlide(2, "bad", "nonexistent-layout", "")
+	_, _, err := d.InsertSlide(2, "bad", "nonexistent-layout", "")
 	if err == nil {
 		t.Fatal("expected error for unknown layout")
 	}
@@ -428,7 +428,7 @@ func TestApplySlots(t *testing.T) {
 	mfs.SetFile("slides/01-a.html", []byte(`A`))
 
 	d, _ := OpenDeck(mfs)
-	_, _ = d.InsertSlide(2, "details", "content", "")
+	_, _, _ = d.InsertSlide(2, "details", "content", "")
 
 	err := d.ApplySlots(2, map[string]string{
 		"body": "<p>Custom body content</p>",
@@ -527,7 +527,7 @@ func makeDeckWithSlugs(t *testing.T, slides ...string) *Deck {
 func TestInsertSlide_ReturnsFinalName(t *testing.T) {
 	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
 
-	finalName, err := d.InsertSlide(2, "middle", "content", "Middle")
+	finalName, _, err := d.InsertSlide(2, "middle", "content", "Middle")
 	if err != nil {
 		t.Fatalf("InsertSlide: %v", err)
 	}
@@ -554,7 +554,7 @@ func TestInsertSlide_SlugCollisionAutoSuffix(t *testing.T) {
 	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
 
 	// Insert with a name that collides with the existing intro slide.
-	finalName, err := d.InsertSlide(3, "intro", "content", "Intro Two")
+	finalName, _, err := d.InsertSlide(3, "intro", "content", "Intro Two")
 	if err != nil {
 		t.Fatalf("InsertSlide: %v", err)
 	}
@@ -585,7 +585,7 @@ func TestInsertSlide_SlugCollisionMultipleSuffix(t *testing.T) {
 		"03-foo-3.html",
 	)
 
-	finalName, err := d.InsertSlide(4, "foo", "content", "")
+	finalName, _, err := d.InsertSlide(4, "foo", "content", "")
 	if err != nil {
 		t.Fatalf("InsertSlide: %v", err)
 	}
@@ -711,6 +711,241 @@ func TestDescribe_IncludesSlug(t *testing.T) {
 	for i, s := range desc.Slides {
 		if s.Slug != want[i] {
 			t.Errorf("slides[%d].Slug = %q, want %q", i, s.Slug, want[i])
+		}
+	}
+}
+
+// --- Slide ID stability tests (#83) ---
+
+// TestSlideID_StableAcrossInsertEarlier verifies that a slide's id is
+// preserved when another slide is inserted before it, causing a position
+// shift and filename renumber. This is the foundational property of
+// slide_id — without it, the entire #83 PR is useless.
+func TestSlideID_StableAcrossInsertEarlier(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-alpha.html", "02-beta.html", "03-gamma.html")
+	// Force id assignment by triggering a mutation.
+	_, idBeta, err := d.InsertSlide(4, "delta", "content", "")
+	if err != nil {
+		t.Fatalf("InsertSlide: %v", err)
+	}
+	_ = idBeta // we'll use the pre-existing beta id instead
+
+	// Capture beta's id (it was at position 2, now might be renumbered).
+	betaID := ""
+	for _, rec := range d.Manifest.Slides {
+		if slideSlugFromFile(rec.File) == "beta" {
+			betaID = rec.ID
+			break
+		}
+	}
+	if betaID == "" {
+		t.Fatal("could not find slide_id for beta")
+	}
+
+	// Insert a new slide at position 1 — pushes everything else.
+	_, _, err = d.InsertSlide(1, "prelude", "content", "")
+	if err != nil {
+		t.Fatalf("InsertSlide at 1: %v", err)
+	}
+
+	// Beta should still have the same id even though its position and
+	// filename prefix changed.
+	betaIDAfter := ""
+	for _, rec := range d.Manifest.Slides {
+		if slideSlugFromFile(rec.File) == "beta" {
+			betaIDAfter = rec.ID
+			break
+		}
+	}
+	if betaIDAfter != betaID {
+		t.Errorf("beta slide_id changed after insert: %q → %q", betaID, betaIDAfter)
+	}
+}
+
+// TestSlideID_StableAcrossRemove verifies that removing an unrelated
+// slide doesn't change other slides' ids.
+func TestSlideID_StableAcrossRemove(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-a.html", "02-b.html", "03-c.html", "04-d.html")
+	// Trigger id assignment.
+	d.ensureSlideIDs()
+	d.saveManifest()
+
+	idC := ""
+	for _, rec := range d.Manifest.Slides {
+		if slideSlugFromFile(rec.File) == "c" {
+			idC = rec.ID
+			break
+		}
+	}
+
+	// Remove slide 1 (a). Slides b, c, d renumber.
+	d.RemoveSlide("01-a.html")
+
+	idCAfter := ""
+	for _, rec := range d.Manifest.Slides {
+		if slideSlugFromFile(rec.File) == "c" {
+			idCAfter = rec.ID
+			break
+		}
+	}
+	if idCAfter != idC {
+		t.Errorf("c slide_id changed after remove: %q → %q", idC, idCAfter)
+	}
+}
+
+// TestSlideID_StableAcrossSlugify verifies the critical rename case:
+// SlugifySlides changes the slug portion of the filename, but the
+// slide_id must remain unchanged. This is the property that makes
+// slide_id stronger than slug as an identifier.
+func TestSlideID_StableAcrossSlugify(t *testing.T) {
+	mfs := templar.NewMemFS()
+	mfs.SetFile("index.html", []byte(`{{# include "slides/01-old-name.html" #}}`))
+	mfs.SetFile("slides/01-old-name.html", []byte(`<section><h1>New Heading</h1></section>`))
+	d, _ := OpenDeck(mfs)
+
+	// Trigger initial id assignment.
+	d.ensureSlideIDs()
+	d.saveManifest()
+
+	idBefore := d.Manifest.Slides[0].ID
+	fileBefore := d.Manifest.Slides[0].File
+
+	// Slugify will rename old-name → new-heading.
+	renamed, err := d.SlugifySlides(Slugify)
+	if err != nil {
+		t.Fatalf("SlugifySlides: %v", err)
+	}
+	if renamed == 0 {
+		t.Fatal("SlugifySlides should have renamed at least 1 slide")
+	}
+
+	// The file field should have changed, but the id must stay the same.
+	if d.Manifest.Slides[0].ID != idBefore {
+		t.Errorf("slide_id changed after slugify: %q → %q", idBefore, d.Manifest.Slides[0].ID)
+	}
+	if d.Manifest.Slides[0].File == fileBefore {
+		t.Error("file should have changed after slugify")
+	}
+
+	// ResolveSlide by the old id should still work.
+	file, err := d.ResolveSlide(idBefore)
+	if err != nil {
+		t.Fatalf("ResolveSlide(%s) after slugify: %v", idBefore, err)
+	}
+	if file == fileBefore {
+		t.Errorf("ResolveSlide returned old file %q; should return new file", fileBefore)
+	}
+}
+
+// TestResolveSlide_BySlideID verifies the priority-0 branch in
+// ResolveSlide: passing a slide_id (sl_-prefixed) resolves directly
+// to the file via the id→file index without position or slug ambiguity.
+func TestResolveSlide_BySlideID(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-intro.html", "02-outro.html")
+	d.ensureSlideIDs()
+
+	id := d.Manifest.Slides[0].ID
+	file, err := d.ResolveSlide(id)
+	if err != nil {
+		t.Fatalf("ResolveSlide(%s): %v", id, err)
+	}
+	if file != "01-intro.html" {
+		t.Errorf("ResolveSlide(%s) = %q, want 01-intro.html", id, file)
+	}
+}
+
+// TestEnsureSlideIDs_LegacyDeck verifies auto-migration: opening a deck
+// that has no slides: section in its manifest, then calling a mutation,
+// results in all slides getting ids assigned.
+func TestEnsureSlideIDs_LegacyDeck(t *testing.T) {
+	d := makeDeckWithSlugs(t, "01-a.html", "02-b.html")
+	// makeDeckWithSlugs doesn't write a manifest, so Manifest is nil or
+	// has no Slides. Force the migration path.
+	d.ensureSlideIDs()
+
+	if len(d.Manifest.Slides) != 2 {
+		t.Fatalf("expected 2 slide records, got %d", len(d.Manifest.Slides))
+	}
+	for _, rec := range d.Manifest.Slides {
+		if !IsSlideID(rec.ID) {
+			t.Errorf("slide record has invalid id %q", rec.ID)
+		}
+	}
+}
+
+// TestEnsureSlideIDs_DoesNotRunOnRead verifies the critical invariant
+// that read-only operations (Describe, list) do NOT trigger auto-migration.
+// This prevents surprise git diffs when users run `slyds describe` on a
+// legacy deck without intending to modify it.
+func TestEnsureSlideIDs_DoesNotRunOnRead(t *testing.T) {
+	mfs := templar.NewMemFS()
+	mfs.SetFile("index.html", []byte(`{{# include "slides/01-a.html" #}}`))
+	mfs.SetFile("slides/01-a.html", []byte(`A`))
+	mfs.SetFile(".slyds.yaml", []byte("theme: default\ntitle: Legacy\n"))
+
+	d, _ := OpenDeck(mfs)
+
+	// Describe is read-only.
+	d.Describe()
+
+	// Re-read the manifest file — it should NOT have a slides: section.
+	data, _ := mfs.ReadFile(".slyds.yaml")
+	if strings.Contains(string(data), "slides:") {
+		t.Error("read-only Describe() wrote slides: section to manifest")
+	}
+}
+
+// TestScaffold_AssignsSlideIDs verifies that newly scaffolded decks have
+// slide_id records for every slide in the manifest from day one.
+func TestScaffold_AssignsSlideIDs(t *testing.T) {
+	mfs := templar.NewMemFS()
+	d, err := ScaffoldDeck(mfs, ScaffoldOpts{
+		Title:      "ID Test",
+		SlideCount: 5,
+		ThemeName:  "default",
+	})
+	if err != nil {
+		t.Fatalf("ScaffoldDeck: %v", err)
+	}
+
+	if len(d.Manifest.Slides) != 5 {
+		t.Fatalf("expected 5 slide records, got %d", len(d.Manifest.Slides))
+	}
+
+	ids := make(map[string]bool)
+	for _, rec := range d.Manifest.Slides {
+		if !IsSlideID(rec.ID) {
+			t.Errorf("invalid slide_id format: %q", rec.ID)
+		}
+		if ids[rec.ID] {
+			t.Errorf("duplicate slide_id: %q", rec.ID)
+		}
+		ids[rec.ID] = true
+	}
+}
+
+// TestDescribe_IncludesSlideID verifies that Describe() populates the
+// SlideID field on every SlideDescription when the manifest has
+// slide records. This is how the MCP describe_deck / list_slides
+// tools expose slide_ids to agents.
+func TestDescribe_IncludesSlideID(t *testing.T) {
+	mfs := templar.NewMemFS()
+	d, err := ScaffoldDeck(mfs, ScaffoldOpts{
+		Title:      "Describe ID Test",
+		SlideCount: 3,
+		ThemeName:  "default",
+	})
+	if err != nil {
+		t.Fatalf("ScaffoldDeck: %v", err)
+	}
+
+	desc, err := d.Describe()
+	if err != nil {
+		t.Fatalf("Describe: %v", err)
+	}
+	for i, s := range desc.Slides {
+		if !IsSlideID(s.SlideID) {
+			t.Errorf("slides[%d].SlideID = %q, want sl_-prefixed id", i, s.SlideID)
 		}
 	}
 }

--- a/core/describe.go
+++ b/core/describe.go
@@ -19,18 +19,20 @@ type DeckDescription struct {
 
 // SlideDescription holds metadata for a single slide.
 //
-// Slug is the stable, human-readable identifier for a slide within a deck.
-// It's derived from the filename by stripping the NN- prefix and .html
-// suffix. Stable across inserts/removes/moves (because RewriteSlideOrder
-// preserves the slug portion when renumbering) but NOT across renames
-// (slugify, manual rename). Agents should prefer Slug over Position when
-// referencing a slide across multiple MCP calls.
+// SlideDescription holds metadata for a single slide.
 //
-// TODO(#83): add SlideID field once .slyds.yaml stores per-slide metadata.
-// SlideID will be rename-safe where Slug is not.
+// Three overlapping identifiers are provided so agents can choose the
+// level of stability they need:
+//
+//   - Position: mutable — changes on insert/remove/move
+//   - Slug: stable across position shifts, but NOT across renames
+//   - SlideID: stable across everything including renames — the truly
+//     immutable handle assigned by slyds and stored in .slyds.yaml.
+//     Empty for legacy decks that haven't been mutated since #83.
 type SlideDescription struct {
 	Position int    `yaml:"position" json:"position"`
 	File     string `yaml:"file" json:"file"`
+	SlideID  string `yaml:"slide_id" json:"slide_id"`
 	Slug     string `yaml:"slug" json:"slug"`
 	Layout   string `yaml:"layout" json:"layout"`
 	Title    string `yaml:"title" json:"title"`
@@ -77,7 +79,8 @@ func (d *Deck) Describe() (*DeckDescription, error) {
 		slideDescs = append(slideDescs, SlideDescription{
 			Position: i + 1,
 			File:     f,
-			Slug:     strings.TrimSuffix(ExtractNamePart(f), ".html"),
+			SlideID:  d.SlideIDForFile(f),
+			Slug:     slideSlugFromFile(f),
 			Layout:   slideLayout,
 			Title:    slideTitle,
 			Words:    wordCount,

--- a/core/manifest.go
+++ b/core/manifest.go
@@ -21,6 +21,20 @@ type SourceConfig struct {
 	Exclude []string `yaml:"exclude,omitempty"`
 }
 
+// SlideRecord maps a stable slide_id to the slide's current filename.
+// The id is assigned by slyds at slide creation time and survives every
+// subsequent mutation: inserts, removes, moves, renumbers, even
+// slugify-style renames. Only the File field changes as the underlying
+// file is renamed on disk. Agents can reference a slide by id for
+// rename-safe access across tool calls.
+//
+// SlideRecord is the per-slide part of the Manifest schema introduced
+// in issue #83.
+type SlideRecord struct {
+	ID   string `yaml:"id"`
+	File string `yaml:"file"`
+}
+
 // Manifest represents the .slyds.yaml file stored in a presentation directory.
 type Manifest struct {
 	Theme           string                  `yaml:"theme"`
@@ -28,6 +42,11 @@ type Manifest struct {
 	Sources         map[string]SourceConfig `yaml:"sources,omitempty"`
 	ModulesDir      string                  `yaml:"modules_dir,omitempty"`
 	AgentIncludeMCP *bool                   `yaml:"agent_include_mcp,omitempty"`
+
+	// Slides is the list of slide_id → filename records. Empty for
+	// legacy decks that predate #83 — they get auto-migrated on the
+	// next mutation. Read-only operations tolerate the empty state.
+	Slides []SlideRecord `yaml:"slides,omitempty"`
 }
 
 // DefaultModulesDir is the default directory name for vendored modules.

--- a/core/manifest_test.go
+++ b/core/manifest_test.go
@@ -49,3 +49,58 @@ func TestManifestFileContents(t *testing.T) {
 		t.Errorf("unexpected manifest content:\n%s", content)
 	}
 }
+
+// TestWriteAndReadManifest_WithSlides verifies that the Slides field
+// (the id → filename mapping introduced in #83) round-trips correctly
+// through yaml.Marshal / yaml.Unmarshal. Every field must survive
+// intact for slide_id lookups to work after a deck is closed and
+// reopened.
+func TestWriteAndReadManifest_WithSlides(t *testing.T) {
+	mfs := templar.NewMemFS()
+	m := Manifest{
+		Theme: "dark",
+		Title: "ID Test",
+		Slides: []SlideRecord{
+			{ID: "sl_a1b2c3d4", File: "01-title.html"},
+			{ID: "sl_deadbeef", File: "02-metrics.html"},
+			{ID: "sl_cafe0123", File: "03-closing.html"},
+		},
+	}
+
+	if err := WriteManifestFS(mfs, m); err != nil {
+		t.Fatalf("WriteManifestFS: %v", err)
+	}
+
+	got, err := ReadManifestFS(mfs)
+	if err != nil {
+		t.Fatalf("ReadManifestFS: %v", err)
+	}
+	if len(got.Slides) != 3 {
+		t.Fatalf("got %d slides after roundtrip, want 3", len(got.Slides))
+	}
+	for i, want := range m.Slides {
+		if got.Slides[i] != want {
+			t.Errorf("slide[%d] = %+v, want %+v", i, got.Slides[i], want)
+		}
+	}
+}
+
+// TestWriteManifest_OmitEmptySlides verifies the `omitempty` tag on the
+// Slides field: a manifest with no slides must not emit a `slides:` key
+// at all, so legacy decks remain byte-identical after a manifest write
+// with an unset Slides field. This keeps git diffs clean during the
+// pre-migration transition period.
+func TestWriteManifest_OmitEmptySlides(t *testing.T) {
+	mfs := templar.NewMemFS()
+	m := Manifest{Theme: "default", Title: "Legacy"}
+
+	if err := WriteManifestFS(mfs, m); err != nil {
+		t.Fatalf("WriteManifestFS: %v", err)
+	}
+
+	data, _ := mfs.ReadFile(".slyds.yaml")
+	content := string(data)
+	if strings.Contains(content, "slides:") {
+		t.Errorf("manifest without Slides field should not emit slides: key, got:\n%s", content)
+	}
+}

--- a/core/query.go
+++ b/core/query.go
@@ -52,6 +52,7 @@ type BatchOperation struct {
 // ResolveSlide resolves a slide reference to a filename from the deck's
 // slide list. Reference forms are tried in this priority order:
 //
+//  0. Slide ID — "sl_a1b2c3d4" matches the id→file mapping in .slyds.yaml
 //  1. Numeric — a 1-based position number ("2" → the second slide)
 //  2. Exact filename — "03-intro.html"
 //  3. Exact slug — "intro" matches "NN-intro.html" for exactly one slide
@@ -60,11 +61,17 @@ type BatchOperation struct {
 // Steps 3 and 4 check for ambiguity: if the reference matches more than one
 // slide, the function returns ErrAmbiguousSlideRef wrapped with the list of
 // candidate filenames, rather than silently picking the first match.
-//
-// TODO(#83): prepend a slide_id lookup branch above the slug match once
-// .slyds.yaml stores per-slide metadata. slide_id is rename-safe where slug
-// is not.
 func (d *Deck) ResolveSlide(ref string) (string, error) {
+	// 0. Slide ID: sl_-prefixed references resolve via the persistent
+	// id→file mapping from .slyds.yaml. This is the most stable form —
+	// it survives every mutation including renames.
+	if IsSlideID(ref) {
+		if file, ok := d.fileByID[ref]; ok {
+			return file, nil
+		}
+		return "", fmt.Errorf("slide id %q not found", ref)
+	}
+
 	slides, err := d.SlideFilenames()
 	if err != nil {
 		return "", err

--- a/core/scaffold_fs.go
+++ b/core/scaffold_fs.go
@@ -84,10 +84,18 @@ func ScaffoldDeck(fsys templar.WritableFS, opts ScaffoldOpts) (*Deck, error) {
 	// Copy static assets from embedded theme
 	copyEmbeddedAssetsFS(fsys, themeName)
 
-	// Write manifest
+	// Write manifest — assign slide_ids to the initial slides so every
+	// scaffolded deck has full id coverage from day one.
+	usedIDs := make(map[string]bool)
+	var slideRecords []SlideRecord
+	for _, f := range slideFiles {
+		id := uniqueSlideID(usedIDs)
+		slideRecords = append(slideRecords, SlideRecord{ID: id, File: f})
+	}
 	manifest := Manifest{
-		Theme: themeName,
-		Title: opts.Title,
+		Theme:  themeName,
+		Title:  opts.Title,
+		Slides: slideRecords,
 	}
 	if !opts.IncludeMCPAgent {
 		f := false
@@ -243,13 +251,13 @@ func copyEmbeddedAssetsFS(fsys templar.WritableFS, theme string) {
 	})
 }
 
-// writeManifestFS writes .slyds.yaml via FS.
+// writeManifestFS writes .slyds.yaml via FS. Delegates to WriteManifestFS
+// (the exported yaml.Marshal path) so new Manifest fields — including the
+// Slides slice from #83 — are serialized correctly. Previously this was a
+// hand-formatted string that silently dropped any field not explicitly
+// named; the switch to yaml.Marshal is a strict correctness improvement.
 func writeManifestFS(fsys templar.WritableFS, m Manifest) error {
-	data := fmt.Sprintf("theme: %s\ntitle: %s\n", m.Theme, m.Title)
-	if m.AgentIncludeMCP != nil && !*m.AgentIncludeMCP {
-		data += "agent_include_mcp: false\n"
-	}
-	return fsys.WriteFile(".slyds.yaml", []byte(data), 0644)
+	return WriteManifestFS(fsys, m)
 }
 
 // readFullManifestFS reads the full Manifest (including Sources) from FS.

--- a/core/slide_id.go
+++ b/core/slide_id.go
@@ -1,0 +1,69 @@
+package core
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// SlideIDPrefix is the literal prefix slyds assigns to every generated
+// slide_id. It serves two purposes:
+//
+//  1. Disambiguation: ResolveSlide can fast-path any reference starting
+//     with this prefix to the slide_id lookup, skipping slug/position
+//     matching.
+//  2. Human readability: agents and users seeing `sl_a1b2c3d4` in logs
+//     or tool responses know it's a slide identifier without ambiguity.
+//
+// The prefix is reserved — callers of InsertSlide that pass a name
+// starting with "sl_" are forbidden (would cause lookup ambiguity).
+const SlideIDPrefix = "sl_"
+
+// slideIDRandomBytes is the number of random bytes used to generate a
+// slide_id. 4 bytes → 8 hex chars → 32 bits. At 100 slides per deck,
+// birthday collision probability is ~1e-6; we retry on collision, so
+// this is effectively zero in practice.
+const slideIDRandomBytes = 4
+
+// newSlideID returns a freshly-generated slide identifier. Format is
+// "sl_" followed by hex-encoded random bytes (see SlideIDPrefix and
+// slideIDRandomBytes). Callers that need uniqueness within a deck
+// should use uniqueSlideID instead.
+func newSlideID() string {
+	var b [slideIDRandomBytes]byte
+	// crypto/rand.Read is documented to never return a short read and
+	// to only error if the system entropy pool is unavailable — which
+	// on any sane OS is a hard failure the rest of the program can't
+	// recover from anyway. Treat an error here as a panic condition.
+	if _, err := rand.Read(b[:]); err != nil {
+		panic(fmt.Sprintf("slyds: failed to read crypto/rand for slide_id: %v", err))
+	}
+	return SlideIDPrefix + hex.EncodeToString(b[:])
+}
+
+// uniqueSlideID returns a newly-generated slide_id that doesn't collide
+// with any id in the provided set. Retries on collision; at the scale
+// slyds operates (dozens to low hundreds of slides per deck), a first-
+// attempt collision is vanishingly rare, so the loop terminates almost
+// immediately. The returned id is added to the used map so subsequent
+// calls with the same map stay consistent.
+func uniqueSlideID(used map[string]bool) string {
+	for {
+		id := newSlideID()
+		if !used[id] {
+			used[id] = true
+			return id
+		}
+	}
+}
+
+// IsSlideID reports whether s looks like a slyds-generated slide_id.
+// Used by ResolveSlide to fast-path id lookups. It only checks the
+// prefix and does not validate the hex portion — a value like
+// "sl_anything" is still treated as a slide_id candidate so that a
+// typo produces a "slide id not found" error rather than falling
+// through to slug/position matching and returning a confusing result.
+func IsSlideID(s string) bool {
+	return strings.HasPrefix(s, SlideIDPrefix)
+}

--- a/core/slide_id_test.go
+++ b/core/slide_id_test.go
@@ -1,0 +1,85 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestNewSlideID_Format verifies that newSlideID returns the expected
+// "sl_" + 8 hex chars format. This is the contract agents and docs
+// rely on when explaining "what does a slide_id look like".
+func TestNewSlideID_Format(t *testing.T) {
+	id := newSlideID()
+
+	if !strings.HasPrefix(id, SlideIDPrefix) {
+		t.Errorf("id %q missing %q prefix", id, SlideIDPrefix)
+	}
+
+	// sl_ (3) + 8 hex chars = 11 total
+	if len(id) != len(SlideIDPrefix)+8 {
+		t.Errorf("id %q has length %d, want %d", id, len(id), len(SlideIDPrefix)+8)
+	}
+
+	hexPart := strings.TrimPrefix(id, SlideIDPrefix)
+	for _, r := range hexPart {
+		isHex := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')
+		if !isHex {
+			t.Errorf("id %q contains non-hex char %q", id, r)
+		}
+	}
+}
+
+// TestNewSlideID_Unique verifies that generating many slide_ids in
+// sequence produces all unique values. At 32 random bits, 100 calls
+// should effectively never collide; this test catches a broken RNG
+// or a seeding bug.
+func TestNewSlideID_Unique(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		id := newSlideID()
+		if seen[id] {
+			t.Errorf("newSlideID collision at iteration %d: %q", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+// TestUniqueSlideID_SkipsUsed verifies that uniqueSlideID never returns
+// an id already present in the used map. Seeds the used map with a
+// known-good id and calls uniqueSlideID once; asserts the result is
+// different AND is recorded in the map for the next call.
+func TestUniqueSlideID_SkipsUsed(t *testing.T) {
+	used := map[string]bool{"sl_abcd1234": true}
+	id := uniqueSlideID(used)
+	if id == "sl_abcd1234" {
+		t.Errorf("uniqueSlideID returned the used id")
+	}
+	if !used[id] {
+		t.Errorf("uniqueSlideID did not record the returned id in the used map")
+	}
+}
+
+// TestIsSlideID verifies the prefix check used by ResolveSlide to
+// fast-path slide_id lookups.
+func TestIsSlideID(t *testing.T) {
+	cases := []struct {
+		ref  string
+		want bool
+	}{
+		{"sl_a1b2c3d4", true},
+		{"sl_", true}, // prefix-only still counts; lookup will fail
+		{"sl_anything", true},
+		{"intro", false},
+		{"03-intro.html", false},
+		{"3", false},
+		{"", false},
+		{"SL_a1b2c3d4", false}, // case-sensitive: the prefix is literal sl_
+	}
+	for _, c := range cases {
+		t.Run(c.ref, func(t *testing.T) {
+			if got := IsSlideID(c.ref); got != c.want {
+				t.Errorf("IsSlideID(%q) = %v, want %v", c.ref, got, c.want)
+			}
+		})
+	}
+}

--- a/core/slide_ids.go
+++ b/core/slide_ids.go
@@ -1,0 +1,119 @@
+package core
+
+import "strings"
+
+// rebuildIndices repopulates the idByFile and fileByID maps from the
+// current Manifest.Slides slice. Call after OpenDeck loads the manifest
+// and after every mutation that changes the Slides records.
+func (d *Deck) rebuildIndices() {
+	d.idByFile = make(map[string]string)
+	d.fileByID = make(map[string]string)
+	if d.Manifest == nil {
+		return
+	}
+	for _, rec := range d.Manifest.Slides {
+		d.idByFile[rec.File] = rec.ID
+		d.fileByID[rec.ID] = rec.File
+	}
+}
+
+// SlideIDForFile returns the slide_id assigned to the given filename,
+// or "" if the file doesn't have an id (legacy deck not yet mutated).
+func (d *Deck) SlideIDForFile(filename string) string {
+	return d.idByFile[filename]
+}
+
+// ensureSlideIDs generates slide_ids for any slide on disk that doesn't
+// yet have one in the manifest. This is the auto-migration path:
+// legacy decks (pre-#83) with no `slides:` section get IDs assigned
+// transparently on the first mutation. The method is idempotent —
+// running it twice in a row is a no-op on the second call.
+//
+// Also prunes stale records whose files no longer exist on disk,
+// healing the manifest if a prior crash left it out of sync.
+//
+// This method modifies Manifest.Slides in place and rebuilds the
+// in-memory indices. The caller is responsible for calling saveManifest
+// afterward if the changes should persist.
+func (d *Deck) ensureSlideIDs() error {
+	if d.Manifest == nil {
+		d.Manifest = &Manifest{}
+	}
+
+	slides, err := d.SlideFilenames()
+	if err != nil {
+		return err
+	}
+
+	// Files already known.
+	known := make(map[string]bool, len(d.Manifest.Slides))
+	for _, rec := range d.Manifest.Slides {
+		known[rec.File] = true
+	}
+
+	// IDs already used (for collision avoidance).
+	usedIDs := make(map[string]bool, len(d.Manifest.Slides))
+	for _, rec := range d.Manifest.Slides {
+		usedIDs[rec.ID] = true
+	}
+
+	// Assign IDs to new files.
+	for _, f := range slides {
+		if known[f] {
+			continue
+		}
+		id := uniqueSlideID(usedIDs)
+		d.Manifest.Slides = append(d.Manifest.Slides, SlideRecord{
+			ID:   id,
+			File: f,
+		})
+	}
+
+	// Prune stale records (file no longer on disk).
+	onDisk := make(map[string]bool, len(slides))
+	for _, f := range slides {
+		onDisk[f] = true
+	}
+	kept := d.Manifest.Slides[:0]
+	for _, rec := range d.Manifest.Slides {
+		if onDisk[rec.File] {
+			kept = append(kept, rec)
+		}
+	}
+	d.Manifest.Slides = kept
+
+	d.rebuildIndices()
+	return nil
+}
+
+// updateSlideFilenames updates the File field of every SlideRecord whose
+// old filename changed after a RewriteSlideOrder or SlugifySlides rename
+// pass. The renames map is oldFilename → newFilename. Records for files
+// not in the renames map are left unchanged. Rebuilds indices after.
+func (d *Deck) updateSlideFilenames(renames map[string]string) {
+	for i := range d.Manifest.Slides {
+		if newName, ok := renames[d.Manifest.Slides[i].File]; ok {
+			d.Manifest.Slides[i].File = newName
+		}
+	}
+	d.rebuildIndices()
+}
+
+// saveManifest writes Manifest to .slyds.yaml on the Deck's filesystem.
+// Call after every successful mutation to persist id→file mapping changes.
+// Returns nil without writing if Manifest is nil (legacy deck with no
+// config file at all — mutation paths init the manifest via ensureSlideIDs
+// so this case effectively can't happen after the first mutation).
+func (d *Deck) saveManifest() error {
+	if d.Manifest == nil {
+		return nil
+	}
+	return WriteManifestFS(d.FS, *d.Manifest)
+}
+
+// slideSlugFromFile extracts the slug portion of a slide filename.
+// Utility that combines ExtractNamePart and the .html suffix strip
+// in a single call.
+func slideSlugFromFile(filename string) string {
+	return strings.TrimSuffix(ExtractNamePart(filename), ".html")
+}

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -115,7 +115,8 @@ Slides have three overlapping identifiers in the MCP API:
 |-----------|-----------------|----------|
 | **Position** (`2`) | same session only | legacy/simple access |
 | **Filename** (`02-metrics.html`) | content edits | you already have it from a previous response |
-| **Slug** (`metrics`) | inserts, removes, moves | you want to re-reference the slide after structural changes |
+| **Slug** (`metrics`) | inserts, removes, moves | you want to re-reference after structural changes |
+| **Slide ID** (`sl_a1b2c3d4`) | everything incl. renames | you want to cache the ID across tool calls |
 
 Agents should prefer **slug** for references that survive insert/remove operations. The `slide` parameter on `read_slide`, `edit_slide`, `query_slide`, and `remove_slide` accepts any of the three forms — the server tries numeric → exact filename → exact slug → substring match.
 
@@ -123,7 +124,9 @@ Agents should prefer **slug** for references that survive insert/remove operatio
 
 **Ambiguous references** return a clear error instead of silently picking the first match. If a substring or slug matches more than one slide, the response lists the candidates so the agent can retry with a specific filename.
 
-Slug is **not rename-safe**: `slyds slides slugify` changes slugs based on `<h1>` headings. A truly rename-safe `slide_id` (stored in `.slyds.yaml`) is planned for a follow-up PR.
+Slug is **not rename-safe**: `slyds slides slugify` changes slugs based on `<h1>` headings. For rename-safe references, use **slide_id** — an opaque `sl_`-prefixed identifier assigned by slyds on slide creation, stored in `.slyds.yaml`, and returned in `describe_deck` / `list_slides` output. Slide IDs survive every mutation including renames.
+
+**Legacy decks** (scaffolded before #83) start without slide IDs and get them auto-assigned on the first mutation. Until then, `describe_deck` returns `""` for `slide_id` — use slug or position instead.
 
 ## Server Configuration (mcpkit v0.1.15)
 


### PR DESCRIPTION
## Summary

Add a rename-safe `slide_id` per slide, stored in `.slyds.yaml` as per-slide `{id, file}` records. Slide IDs survive every mutation — inserts, removes, moves, content edits, AND renames. This is the truly stable identifier the optimistic versioning work (#79) will lock on.

**Zero breaking changes for existing agents.** `slide_id` is an additive field in `describe_deck`/`list_slides` output and an additive resolution form in `read_slide`/`edit_slide`/`query_slide`/`remove_slide` via the existing `slide` parameter.

## What this unblocks

- **#79 (optimistic versioning)**: can lock on `slide_id` instead of slug, so a concurrent rename produces a clean version conflict instead of a confusing "not found" error
- **Hosted MCP (#76)**: `slide_id` maps 1:1 to a DB primary key without translation

## Design

### `.slyds.yaml` schema

```yaml
theme: dark
title: "My Presentation"
slides:
  - id: sl_a1b2c3d4
    file: 01-title.html
  - id: sl_deadbeef
    file: 02-metrics.html
```

`id` is `sl_` + 8 hex chars (32 random bits from `crypto/rand`). `file` tracks the slide's **current** filename — mutates on every rename/renumber while the id stays constant. `omitempty` means legacy decks stay clean until first mutation.

### Pre-req refactors (included)

1. **`DeckManifest` → `*Manifest`**: eliminated the minimal shadow type on `Deck.Manifest`. Now carries the full manifest including `Slides`, `Sources`, etc.
2. **`writeManifestFS` → `WriteManifestFS`**: the unexported hand-formatter that silently dropped new fields now delegates to proper `yaml.Marshal`.

### Stability matrix

| Mutation | slide_id | slug | position |
|----------|----------|------|----------|
| Edit content | stable | stable | stable |
| Insert slide | **stable** | stable | changes |
| Remove slide | **stable** | stable | changes |
| Move slide | **stable** | stable | changes |
| Rename (slugify) | **stable** | **changes** | stable |

### Auto-migration

Legacy decks (pre-PR) get IDs assigned on first mutation — not on read. `slyds describe` on a legacy deck returns `""` for `slide_id` without modifying `.slyds.yaml`. First `add_slide`, `edit_slide`, or `remove_slide` triggers auto-migration.

### `ResolveSlide` priority chain

```
0. Slide ID (sl_-prefixed → id→file lookup)  ← NEW
1. Numeric (position)
2. Exact filename
3. Exact slug
4. Substring fallback
```

## Files (19 changed, +855/-71)

| File | Change |
|------|--------|
| `core/manifest.go` | `SlideRecord` type + `Manifest.Slides` field |
| `core/slide_id.go` | **NEW** — `newSlideID`, `uniqueSlideID`, `IsSlideID` |
| `core/slide_ids.go` | **NEW** — `rebuildIndices`, `ensureSlideIDs`, `saveManifest`, `updateSlideFilenames`, `slideSlugFromFile` |
| `core/deck.go` | Delete `DeckManifest`; `Deck.Manifest → *Manifest`; add `idByFile`/`fileByID` indices; wire all 6 mutation methods; `InsertSlide → (slug, slideID, error)` |
| `core/query.go` | `ResolveSlide` slide_id priority-0 branch |
| `core/describe.go` | `SlideDescription.SlideID` field |
| `core/scaffold_fs.go` | Scaffolder assigns IDs; `writeManifestFS` → `WriteManifestFS` |
| `cmd/mcp_tools.go` | `add_slide` response includes slide_id |
| `cmd/slides.go` | InsertSlide 3-value return |
| Tests | 14 new tests across `core/` and `cmd/` |
| Docs | CLAUDE.md, ARCHITECTURE.md, docs/MCP.md, ROADMAP.md, NEXTSTEPS.md |

## Test plan

- [x] `TestSlideID_StableAcrossInsertEarlier` — slide_id preserved when earlier insert shifts position
- [x] `TestSlideID_StableAcrossRemove` — slide_id preserved when unrelated slide removed
- [x] `TestSlideID_StableAcrossSlugify` — **the rename case**: slugify changes filename, id stays same
- [x] `TestResolveSlide_BySlideID` — resolve by sl_-prefixed id
- [x] `TestEnsureSlideIDs_LegacyDeck` — auto-migration assigns ids to all slides
- [x] `TestEnsureSlideIDs_DoesNotRunOnRead` — **critical**: Describe() doesn't write to disk
- [x] `TestScaffold_AssignsSlideIDs` — 5-slide scaffold has 5 unique ids in manifest
- [x] `TestDescribe_IncludesSlideID` — SlideID field populated in output
- [x] `TestWriteAndReadManifest_WithSlides` — round-trip through yaml.Marshal
- [x] `TestWriteManifest_OmitEmptySlides` — legacy manifests don't emit slides: key
- [x] `TestE2E_SlideIDSurvivesRename` — **canonical integration test**: scaffold, edit, slugify, read by original slide_id — proves the whole PR's motivation end-to-end
- [x] All existing tests unchanged and passing
- [x] Constraint check: no new regex HTML mutation
- [x] Smoke: `slyds init -n 5` → `.slyds.yaml` has 5 unique sl_ IDs; `slyds slugify` preserves them

### Assertion audit

- **Added**: 14 new test functions, ~50+ assertions
- **Modified**: ~10 InsertSlide callers updated to 3-value return (mechanical)
- **Weakened**: 0

Closes #83. Unblocks #79.