### PR TITLE
feat: streaming build progress + schema validation (#87, #88)

### DIFF
--- a/NEXTSTEPS.md
+++ b/NEXTSTEPS.md
@@ -45,6 +45,7 @@
 - [x] ~~Workspace abstraction — `cmd/workspace.go`, `slyds ws` CLI, MCP middleware-based deck resolution (#74, PR 1 of 4)~~
 - [x] ~~Slug-as-ID in MCP tools + slug uniqueness — `Slug` field, priority-chain `ResolveSlide`, scaffolder fix, `slide` param on read/edit (#78, #74 PR 2 of 4)~~
 - [x] ~~Persistent slide IDs in `.slyds.yaml` — rename-safe `sl_` IDs stored per-slide in manifest, auto-migrated, ResolveSlide priority-0 branch (#83)~~
+- [x] ~~Streaming build progress via EmitContent (#87) + server-side schema validation (#88)~~
 - [ ] Optimistic versioning on MCP mutations (#79, locks on slide_id)
 - [ ] Multi-root workspace.yaml config (#80)
 - [ ] Slide folders with co-located assets (e.g., `slides/03-architecture/slide.html` + `diagram.png`)

--- a/cmd/mcp_apps.go
+++ b/cmd/mcp_apps.go
@@ -97,6 +97,9 @@ func registerAppTools(srv *server.Server) {
 			if errResult != nil {
 				return *errResult, nil
 			}
+			mcpcore.EmitContent(ctx, req.RequestID, mcpcore.Content{
+				Type: "text", Text: fmt.Sprintf("Building preview for %q...", p.Deck),
+			})
 			result, err := buildDeckForPreview(d)
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
@@ -168,6 +171,9 @@ func registerAppTools(srv *server.Server) {
 				)), nil
 			}
 
+			mcpcore.EmitContent(ctx, req.RequestID, mcpcore.Content{
+				Type: "text", Text: fmt.Sprintf("Building preview for %q (slide %d)...", p.Deck, p.Position),
+			})
 			result, err := buildDeckForPreview(d)
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil

--- a/cmd/mcp_e2e_test.go
+++ b/cmd/mcp_e2e_test.go
@@ -355,6 +355,59 @@ func TestPerToolTimeout(t *testing.T) {
 	}
 }
 
+// TestE2E_SchemaValidation_RejectsInvalidArgs verifies that mcpkit's
+// server-side JSON Schema validation (active by default in v0.1.24)
+// rejects malformed tool arguments with a -32602 error before the
+// handler runs. This is the contract that lets agents rely on structured
+// error data (field path, keyword) to fix their arguments without a
+// round-trip through the handler's error handling.
+func TestE2E_SchemaValidation_RejectsInvalidArgs(t *testing.T) {
+	root := t.TempDir()
+	core.CreateInDir("Schema Test", 2, "default", fmt.Sprintf("%s/test-deck", root), true)
+
+	c := newSlydsMCPClient(t, root)
+
+	// Call read_slide with position as a string instead of the required int.
+	// The schema declares position as "type": "integer"; a string should be
+	// rejected by the schema validator, not by the handler.
+	_, err := c.Client.ToolCall("read_slide", map[string]any{
+		"deck":     "test-deck",
+		"position": "not-a-number",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid position type, got nil")
+	}
+	errMsg := err.Error()
+	// mcpkit returns -32602 for schema validation failures.
+	if !strings.Contains(errMsg, "-32602") && !strings.Contains(errMsg, "validation") {
+		t.Errorf("expected -32602 schema validation error; got: %s", errMsg)
+	}
+}
+
+// TestBuildDeckTool_WithEmitContent verifies that adding EmitContent
+// progress calls to the build_deck handler doesn't change the final
+// result. EmitContent is silently dropped on the JSON path used by
+// testutil.TestClient, so this is a regression guard for the return
+// value — not a test of streaming delivery (which is an mcpkit
+// transport concern tested upstream).
+func TestBuildDeckTool_WithEmitContent(t *testing.T) {
+	root := scaffoldTestDeck(t, "test-deck", "Progress Test", "default", 3)
+	tool := buildDeckTool()
+
+	result := callTool(t, root, tool.Handler, map[string]string{"deck": "test-deck"})
+	if result.IsError {
+		t.Fatalf("build_deck error: %s", toolText(result))
+	}
+
+	text := toolText(result)
+	if !strings.Contains(text, "<style>") {
+		t.Error("build_deck missing inlined CSS after EmitContent addition")
+	}
+	if !strings.Contains(text, "Progress Test") {
+		t.Error("build_deck missing title after EmitContent addition")
+	}
+}
+
 // TestE2E_SlideIDSurvivesRename is the canonical integration test for
 // slide_id (#83): it proves that a slide_id reference survives a rename
 // (slugify) that changes the slide's slug and filename — the exact

--- a/cmd/mcp_tools.go
+++ b/cmd/mcp_tools.go
@@ -479,6 +479,9 @@ func checkDeckTool() server.Tool {
 			if errResult != nil {
 				return *errResult, nil
 			}
+			mcpcore.EmitContent(ctx, req.RequestID, mcpcore.Content{
+				Type: "text", Text: fmt.Sprintf("Validating deck %q...", p.Deck),
+			})
 			issues, err := d.Check()
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil
@@ -505,6 +508,9 @@ func buildDeckTool() server.Tool {
 			if errResult != nil {
 				return *errResult, nil
 			}
+			mcpcore.EmitContent(ctx, req.RequestID, mcpcore.Content{
+				Type: "text", Text: fmt.Sprintf("Building deck %q...", p.Deck),
+			})
 			result, err := d.Build()
 			if err != nil {
 				return mcpcore.ErrorResult(err.Error()), nil

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -130,6 +130,14 @@ Slug is **not rename-safe**: `slyds slides slugify` changes slugs based on `<h1>
 
 ## Server Configuration (mcpkit v0.1.24)
 
+### Streaming Progress
+
+`build_deck`, `check_deck`, `preview_deck`, and `preview_slide` emit progress chunks via `EmitContent` before the main operation runs (e.g., "Building deck 'q3-review'..."). Clients connected via SSE or Streamable HTTP with a content chunk handler see real-time progress; clients without chunk support see only the final result. The final result is authoritative — chunks are purely informational.
+
+### Schema Validation
+
+Server-side JSON Schema validation is active by default. Tool arguments are validated against the declared `InputSchema` before the handler runs. Malformed arguments (wrong type, missing required fields) produce a `-32602 Invalid Params` JSON-RPC error with structured error data. Agents can parse the error to identify which field needs correction without a handler round-trip.
+
 ### Per-Tool Timeouts
 
 `build_deck` (30s) and `check_deck` (10s) have per-tool timeouts via `ToolDef.Timeout`. Other tools use the server default. This prevents long-running builds from being killed by a short global timeout while keeping fast tools responsive.


### PR DESCRIPTION
## Summary

Two small mcpkit v0.1.24 integrations bundled together — both independent, both in `cmd/`.

### Streaming progress (#87)

`build_deck`, `check_deck`, `preview_deck`, and `preview_slide` now emit progress chunks via `core.EmitContent` before the main operation runs:

```
→ tools/call build_deck {deck: "q3-review"}
← [chunk] Building deck "q3-review"...
← <html>...(final result)...</html>
```

Clients with `WithContentChunkHandler` see real-time progress. Clients without it see only the final result (backward compatible — chunks are silently dropped on the JSON response path).

Deeper per-phase progress (CSS → JS → images) would require a `core.Build()` progress callback — deferred to a follow-up.

### Schema validation (#88)

mcpkit v0.1.24's server-side JSON Schema validation is already active by default. Tool arguments are validated against `InputSchema` at dispatch time — malformed arguments get rejected with `-32602 Invalid Params` before the handler runs.

This PR adds a test proving it works and documents it in docs/MCP.md.

## Files (5 changed, +74)

| File | Change |
|------|--------|
| `cmd/mcp_tools.go` | `EmitContent` calls in `build_deck` and `check_deck` |
| `cmd/mcp_apps.go` | `EmitContent` calls in `preview_deck` and `preview_slide` |
| `cmd/mcp_e2e_test.go` | `TestE2E_SchemaValidation_RejectsInvalidArgs` + `TestBuildDeckTool_WithEmitContent` |
| `docs/MCP.md` | New "Streaming Progress" and "Schema Validation" sections |
| `NEXTSTEPS.md` | Check off #87 and #88 |

## Test plan

- [x] `TestBuildDeckTool_WithEmitContent` — regression guard: EmitContent doesn't interfere with final result
- [x] `TestE2E_SchemaValidation_RejectsInvalidArgs` — invalid `position: "not-a-number"` produces `-32602`
- [x] All existing tests pass unchanged

Closes #87. Closes #88.